### PR TITLE
Add PyTorch operator-level SDC detection module

### DIFF
--- a/pytorch_op/__init__.py
+++ b/pytorch_op/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.

--- a/pytorch_op/__main__.py
+++ b/pytorch_op/__main__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/pytorch_op/cross_gpu.py
+++ b/pytorch_op/cross_gpu.py
@@ -1,0 +1,774 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Cross-GPU SDC detection: runs the same ops on all GPUs and compares results.
+
+This catches deterministic-but-wrong errors that self-comparison misses.
+Model-level cpbench detects SDC by comparing checksums across GPUs;
+this module does the same at the operator level.
+
+Always tests all GPUs on the box.
+"""
+
+import csv
+import hashlib
+import io
+import logging
+import signal
+import subprocess
+import time
+from collections import OrderedDict
+from typing import Dict, List, Optional, Set, Tuple
+
+import torch
+
+from .ops import DTYPE_MAP, OP_REGISTRY, OpDef, PIPELINE_REGISTRY
+from .precision import enable_deterministic_mode, resolve_dtype, set_precision_mode
+
+logger = logging.getLogger("pytorch_op_crossgpu")
+
+
+class _TimeLimitReached(Exception):
+    """Raised by SIGALRM when the duration limit is hit."""
+
+
+DEFAULT_SIZES = [
+    (1024, 1024),
+    (4096, 4096),
+    (8192, 8192),
+]
+
+
+class CrossGPUDetector:
+    """Runs ops on multiple GPUs and compares results across GPUs."""
+
+    def __init__(
+        self,
+        gpu_ids: List[int],
+        test_sizes=None,
+        hash_inputs: bool = False,
+    ):
+        self.gpu_ids = gpu_ids
+        self._test_sizes = test_sizes or DEFAULT_SIZES
+        self.current_dtype = torch.float32
+        self._failures: List[str] = []
+        self._hash_inputs = hash_inputs
+        self._gpu_disagreements: Dict[int, Set[int]] = {g: set() for g in gpu_ids}
+        self.device: str = f"cuda:{gpu_ids[0]}"
+        self._gpu_serials: Dict[int, str] = self._get_gpu_serials()
+        self._run_max_diff: float = 0.0
+        self._run_total_mismatched: int = 0
+        self._run_total_elements: int = 0
+        self._all_peers_disagree: bool = False
+
+    @staticmethod
+    def _get_gpu_serials() -> Dict[int, str]:
+        """Get GPU serial numbers mapped to PyTorch rank.
+
+        On AMD, PyTorch assigns GPU ranks by Node ID order (not DRM card
+        index).  GPU rank 0 is the card with the lowest Node ID, rank 1
+        the next, and so on.
+
+        On NVIDIA, GPU index from nvidia-smi matches PyTorch rank
+        directly (PCI bus order).
+        """
+        serials = CrossGPUDetector._get_amd_serials()
+        if serials:
+            return serials
+        return CrossGPUDetector._get_nvidia_serials()
+
+    @staticmethod
+    def _get_amd_serials() -> Dict[int, str]:
+        """Parse rocm-smi CSV, sort by Node ID, map sorted index to rank."""
+        try:
+            result = subprocess.run(
+                ["rocm-smi", "--showproductname", "--showserial", "--showbus", "--csv"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0 or "Node ID" not in result.stdout:
+                return {}
+            reader = csv.DictReader(io.StringIO(result.stdout))
+            entries = []
+            for row in reader:
+                node_id = row.get("Node ID", "").strip()
+                serial = row.get("Serial Number", "").strip()
+                if node_id and serial:
+                    entries.append((int(node_id), serial))
+            if not entries:
+                return {}
+            entries.sort(key=lambda x: x[0])
+            return {rank: serial for rank, (_nid, serial) in enumerate(entries)}
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return {}
+
+    @staticmethod
+    def _get_nvidia_serials() -> Dict[int, str]:
+        """Parse nvidia-smi CSV — GPU index already matches PyTorch rank."""
+        serials: Dict[int, str] = {}
+        try:
+            result = subprocess.run(
+                [
+                    "nvidia-smi",
+                    "--query-gpu=index,serial",
+                    "--format=csv,noheader,nounits",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.strip().splitlines():
+                    parts = line.split(",")
+                    if len(parts) == 2:
+                        serials[int(parts[0].strip())] = parts[1].strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+        return serials
+
+    def create_test_tensor(self, shape, dtype=None):
+        dtype = dtype or self.current_dtype
+        torch.manual_seed(42)
+        if dtype in (torch.float16, torch.bfloat16):
+            return torch.randn(shape, dtype=torch.float32, device=self.device).to(dtype)
+        return torch.randn(shape, dtype=dtype, device=self.device)
+
+    def _hash_tensor(self, t: torch.Tensor) -> str:
+        """Compute a stable hash of a tensor's contents."""
+        data = t.cpu().contiguous().float().numpy().tobytes()
+        return hashlib.sha256(data).hexdigest()[:16]
+
+    def _run_op_on_gpu(
+        self, gpu_id: int, op_def: OpDef, size
+    ) -> Optional[Tuple[torch.Tensor, Optional[str], float]]:
+        """Run a single op on a specific GPU and return (result_on_cpu, input_hash, elapsed_ms)."""
+        self.device = f"cuda:{gpu_id}"
+        try:
+            enable_deterministic_mode()
+            # Capture input tensor for hashing
+            torch.manual_seed(42)
+            input_tensor = self.create_test_tensor(size)
+            input_hash = self._hash_tensor(input_tensor) if self._hash_inputs else None
+            del input_tensor
+
+            # Re-seed and run the actual op with GPU timing
+            operation = op_def.factory(self, size)
+            with torch.cuda.device(gpu_id):
+                start_event = torch.cuda.Event(enable_timing=True)
+                end_event = torch.cuda.Event(enable_timing=True)
+                start_event.record()
+                result = operation()
+                end_event.record()
+                torch.cuda.synchronize()
+                elapsed_ms = start_event.elapsed_time(end_event)
+
+                if isinstance(result, torch.Tensor):
+                    return (result.cpu(), input_hash, elapsed_ms)
+                return (result, input_hash, elapsed_ms)
+        except RuntimeError as e:
+            if "out of memory" in str(e):
+                logger.warning(f"  GPU {gpu_id}: OOM - skipping")
+                torch.cuda.empty_cache()
+                return None
+            raise
+        finally:
+            torch.cuda.empty_cache()
+
+    @staticmethod
+    def _nan_aware_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+        """Compare two tensors treating NaN==NaN as True.
+
+        IEEE 754 says NaN != NaN, so ``torch.equal`` returns False when
+        both tensors contain NaN in the same positions.  This helper
+        masks NaN positions before comparing the non-NaN elements.
+        """
+        nan_a = torch.isnan(a)
+        nan_b = torch.isnan(b)
+        if nan_a.any() or nan_b.any():
+            # NaN positions must match exactly
+            if not torch.equal(nan_a, nan_b):
+                return False
+            # Compare only non-NaN elements
+            non_nan = ~nan_a
+            if non_nan.any():
+                return torch.equal(a[non_nan], b[non_nan])
+            # Both are entirely NaN — treat as equal
+            return True
+        return torch.equal(a, b)
+
+    def _report_mismatch(
+        self,
+        ref_gpu: int,
+        other_gpu: int,
+        op_name: str,
+        ref: torch.Tensor,
+        output: torch.Tensor,
+        verbose: bool,
+    ) -> None:
+        """Log a cross-GPU mismatch and update run-level diff stats."""
+        ref_f32 = ref.float()
+        out_f32 = output.float()
+        diff = torch.abs(ref_f32 - out_f32)
+        # Mask out NaN positions so they don't poison diff stats
+        nan_mask = torch.isnan(diff)
+        if nan_mask.any():
+            diff = diff.clone()
+            diff[nan_mask] = 0.0
+        mismatch_mask = diff > 0
+        mismatches = int(mismatch_mask.sum().item())
+        total = ref.numel()
+        max_diff = diff.max().item()
+
+        self._run_max_diff = max(self._run_max_diff, max_diff)
+        self._run_total_mismatched += mismatches
+        self._run_total_elements += total
+
+        # Report NaN divergence separately when NaN positions differ
+        nan_ref = torch.isnan(ref_f32)
+        nan_out = torch.isnan(out_f32)
+        nan_only_ref = int((nan_ref & ~nan_out).sum().item())
+        nan_only_out = int((nan_out & ~nan_ref).sum().item())
+        nan_note = ""
+        if nan_only_ref or nan_only_out:
+            nan_note = (
+                f", NaN divergence: {nan_only_ref} in ref / {nan_only_out} in other"
+            )
+
+        logger.error(
+            f"FAIL: GPU {ref_gpu} vs GPU {other_gpu}, {op_name}, "
+            f"max_diff={max_diff:.2e}, "
+            f"{mismatches}/{total} mismatched{nan_note}"
+        )
+
+        if verbose:
+            self._log_verbose_diff(
+                ref_gpu, other_gpu, ref, ref_f32, out_f32, diff, mismatch_mask
+            )
+
+        self._failures.append(
+            f"{op_name} (GPU {ref_gpu} vs {other_gpu}: "
+            f"max_diff={max_diff:.2e}, {mismatches}/{total} mismatched)"
+        )
+
+    def _compare_cross_gpu(
+        self,
+        op_name: str,
+        results: Dict[int, Tuple[torch.Tensor, Optional[str]]],
+        verbose: bool = False,
+    ) -> bool:
+        """Compare results across GPUs. Returns True if all match.
+
+        Concise mode (default): one line per failure.
+        Verbose mode: full element-level diffs, byte offsets, sample values.
+        Also tracks per-GPU disagreements (all-pairs) for the summary.
+        """
+        gpu_ids = sorted(results.keys())
+        if len(gpu_ids) < 2:
+            logger.warning(
+                f"  {op_name}: only {len(gpu_ids)} GPU(s) produced results, need >= 2"
+            )
+            return True
+
+        ref_gpu = gpu_ids[0]
+        ref, ref_input_hash = results[ref_gpu]
+        all_match = True
+
+        # Check input hashes
+        if self._hash_inputs:
+            for gpu_id in gpu_ids[1:]:
+                _, other_hash = results[gpu_id]
+                if other_hash != ref_input_hash:
+                    logger.error(
+                        f"FAIL: GPU {ref_gpu} vs GPU {gpu_id}, {op_name}, "
+                        f"INPUT HASH MISMATCH -- memory corruption"
+                    )
+                    if verbose:
+                        logger.error(
+                            f"  GPU {ref_gpu}={ref_input_hash} vs "
+                            f"GPU {gpu_id}={other_hash}"
+                        )
+                    self._failures.append(
+                        f"{op_name} (GPU {ref_gpu} vs {gpu_id}: INPUT HASH MISMATCH)"
+                    )
+                    all_match = False
+
+        # Compare outputs
+        for gpu_id in gpu_ids[1:]:
+            output, _ = results[gpu_id]
+            if output.shape != ref.shape:
+                logger.error(
+                    f"FAIL: GPU {ref_gpu} vs GPU {gpu_id}, {op_name}, "
+                    f"shape mismatch {ref.shape} vs {output.shape}"
+                )
+                self._failures.append(f"{op_name} (GPU {ref_gpu} vs {gpu_id}: shape)")
+                all_match = False
+                continue
+
+            if not self._nan_aware_equal(ref, output):
+                self._report_mismatch(ref_gpu, gpu_id, op_name, ref, output, verbose)
+                all_match = False
+
+        # Track per-GPU disagreements via all-pairs comparison
+        if not all_match:
+            self._track_disagreements(gpu_ids, results)
+
+        return all_match
+
+    def _log_verbose_diff(
+        self,
+        ref_gpu: int,
+        other_gpu: int,
+        ref: torch.Tensor,
+        ref_f32: torch.Tensor,
+        out_f32: torch.Tensor,
+        diff: torch.Tensor,
+        mismatch_mask: torch.Tensor,
+    ) -> None:
+        """Log detailed corruption analysis for verbose mode."""
+        mismatches = int(mismatch_mask.sum().item())
+
+        # Stuck-at-zero pattern
+        zero_mask = (out_f32 == 0) & (ref_f32 != 0)
+        zeroed_count = int(zero_mask.sum().item())
+        if zeroed_count > 0:
+            logger.error(
+                f"  ZEROED VALUES: {zeroed_count}/{mismatches} corrupted "
+                f"elements are zero (stuck-at-zero pattern)"
+            )
+
+        # Corruption geometry (capped to avoid log flood)
+        max_lines = 10
+        if mismatches > 0 and ref.dim() >= 2:
+            mismatch_indices = torch.nonzero(mismatch_mask, as_tuple=False)
+            if len(mismatch_indices) > 0 and ref.dim() == 2:
+                rows = mismatch_indices[:, 0]
+                cols = mismatch_indices[:, 1]
+                unique_rows = rows.unique()
+                lines = 0
+                for row in unique_rows:
+                    if lines >= max_lines:
+                        logger.error(
+                            f"  GEOMETRY: ... {len(unique_rows) - lines} more "
+                            f"rows omitted"
+                        )
+                        break
+                    row_cols = cols[rows == row].sort()[0]
+                    start_col = row_cols[0].item()
+                    byte_offset = start_col * ref.element_size()
+                    if len(row_cols) > 1:
+                        is_contiguous = (row_cols[1:] - row_cols[:-1] == 1).all().item()
+                        aligned_32b = (byte_offset % 32) == 0
+                        logger.error(
+                            f"  GEOMETRY: row {row.item()}, "
+                            f"cols {row_cols[0].item()}-{row_cols[-1].item()} "
+                            f"({len(row_cols)} elements, "
+                            f"{'contiguous' if is_contiguous else 'non-contiguous'}, "
+                            f"byte_offset={byte_offset}, "
+                            f"{'32B-aligned' if aligned_32b else 'NOT 32B-aligned'})"
+                        )
+                    else:
+                        logger.error(
+                            f"  GEOMETRY: row {row.item()}, col {start_col} "
+                            f"(1 element, byte_offset={byte_offset})"
+                        )
+                    lines += 1
+
+                # Flat byte offsets
+                flat_indices = torch.nonzero(
+                    mismatch_mask.flatten(), as_tuple=False
+                ).squeeze()
+                if flat_indices.dim() == 0:
+                    flat_indices = flat_indices.unsqueeze(0)
+                byte_offsets = flat_indices * ref.element_size()
+                logger.error(
+                    f"  BYTE OFFSETS of corrupted elements: "
+                    f"{byte_offsets[:10].tolist()}"
+                    f"{'...' if len(byte_offsets) > 10 else ''}"
+                )
+
+        # Top mismatches
+        top_diffs = torch.topk(diff.flatten(), min(5, diff.numel()))
+        for idx in top_diffs.indices:
+            pos = idx.item()
+            logger.error(
+                f"  [{pos}]: "
+                f"GPU{ref_gpu}={ref_f32.flatten()[pos].item():.10e}, "
+                f"GPU{other_gpu}={out_f32.flatten()[pos].item():.10e}, "
+                f"diff={diff.flatten()[pos].item():.10e}"
+            )
+
+    def _track_disagreements(
+        self,
+        gpu_ids: List[int],
+        results: Dict[int, Tuple[torch.Tensor, Optional[str]]],
+    ) -> None:
+        """Track all-pairs GPU disagreements for the summary."""
+        outputs = {g: results[g][0] for g in gpu_ids}
+        for i, ga in enumerate(gpu_ids):
+            for gb in gpu_ids[i + 1 :]:
+                differs = outputs[ga].shape != outputs[
+                    gb
+                ].shape or not self._nan_aware_equal(outputs[ga], outputs[gb])
+                if differs:
+                    self._gpu_disagreements[ga].add(gb)
+                    self._gpu_disagreements[gb].add(ga)
+        if self._hash_inputs:
+            hashes = {g: results[g][1] for g in gpu_ids}
+            for i, ga in enumerate(gpu_ids):
+                for gb in gpu_ids[i + 1 :]:
+                    if hashes[ga] is not None and hashes[ga] != hashes[gb]:
+                        self._gpu_disagreements[ga].add(gb)
+                        self._gpu_disagreements[gb].add(ga)
+
+    def run(
+        self,
+        categories: Optional[List[str]] = None,
+        dtypes: Optional[List[str]] = None,
+        iterations: int = 1,
+        run_pipelines: bool = False,
+        fail_fast: bool = False,
+        verbose: bool = False,
+        precision_modes: Optional[List[str]] = None,
+        duration_limit: Optional[int] = None,
+    ) -> dict:
+        """Run cross-GPU comparison tests.
+
+        For each op, runs it on every GPU and compares results.
+        Repeats ``iterations`` times to catch intermittent SDC.
+
+        Returns a dict with pass/fail counts, timing, and per-GPU
+        disagreement info for identifying bad GPUs.
+        """
+        dtypes = dtypes or ["float32"]
+        resolved_dtypes = [DTYPE_MAP[d.strip()] for d in dtypes]
+        precision_modes = precision_modes or ["fp32"]
+
+        logger.info(f"Cross-GPU SDC detection on GPUs: {self.gpu_ids}")
+        logger.info(f"Iterations per op: {iterations}")
+        logger.info(f"Dtypes: {dtypes}")
+        logger.info(f"Precision modes: {precision_modes}")
+        logger.info(f"Sizes: {self._test_sizes}")
+        if fail_fast:
+            logger.info("Fail-fast: ON")
+        if verbose:
+            logger.info("Verbose: ON")
+        if duration_limit is not None:
+            logger.info(f"Duration limit: {duration_limit}s (hard cap)")
+
+        start_time = time.time()
+        self._failures = []
+        self._gpu_disagreements = {g: set() for g in self.gpu_ids}
+        self._run_max_diff = 0.0
+        self._run_total_mismatched = 0
+        self._run_total_elements = 0
+        self._all_peers_disagree = False
+        total = 0
+        passed = 0
+        stopped = False
+        time_limited = False
+
+        # Set up SIGALRM for hard duration cap — interrupts immediately,
+        # even mid-CUDA-call, no waiting for any op/kernel to finish.
+        old_handler = None
+        if duration_limit is not None:
+
+            def _alarm_handler(signum, frame):
+                raise _TimeLimitReached()
+
+            old_handler = signal.getsignal(signal.SIGALRM)
+            signal.signal(signal.SIGALRM, _alarm_handler)
+            signal.alarm(duration_limit)
+
+        try:
+            # --- Individual op tests ---
+            for pmode in precision_modes:
+                if stopped:
+                    break
+                set_precision_mode(pmode)
+                mode_dtype = resolve_dtype(pmode)
+                pmode_label = pmode.upper()
+
+                if len(precision_modes) > 1:
+                    logger.info(f"=== Precision mode: {pmode_label} ===")
+
+                for dtype in resolved_dtypes:
+                    if stopped:
+                        break
+                    # Dtype-based precision modes fix the dtype
+                    if pmode in ("fp16", "bf16", "fp8"):
+                        self.current_dtype = mode_dtype
+                    else:
+                        self.current_dtype = dtype
+                    dtype_name = str(self.current_dtype).replace("torch.", "")
+                    if len(resolved_dtypes) > 1 and pmode in ("fp32", "tf32"):
+                        logger.info(f"  === Dtype: {dtype_name} ===")
+
+                    for size in self._test_sizes:
+                        if stopped:
+                            break
+                        logger.info(f"--- Size: {size} ({pmode_label}) ---")
+
+                        grouped: OrderedDict[str, List[OpDef]] = OrderedDict()
+                        for op_def in OP_REGISTRY:
+                            if categories and op_def.category not in categories:
+                                continue
+                            grouped.setdefault(op_def.category, []).append(op_def)
+
+                        for category, ops in grouped.items():
+                            if stopped:
+                                break
+                            logger.info(f"  [{category.replace('_', ' ').title()}]")
+                            for op_def in ops:
+                                if stopped:
+                                    break
+                                op_ok = True
+                                for it in range(iterations):
+                                    results = {}
+                                    for gpu_id in self.gpu_ids:
+                                        r = self._run_op_on_gpu(gpu_id, op_def, size)
+                                        if r is not None:
+                                            result_tensor, input_hash, elapsed_ms = r
+                                            results[gpu_id] = (
+                                                result_tensor,
+                                                input_hash,
+                                            )
+
+                                    total += 1
+                                    label = op_def.name
+                                    if len(precision_modes) > 1:
+                                        label = f"{label} [{pmode_label}]"
+                                    if iterations > 1:
+                                        label = f"{label} iter {it + 1}/{iterations}"
+                                    if self._compare_cross_gpu(
+                                        label, results, verbose=verbose
+                                    ):
+                                        passed += 1
+                                    else:
+                                        op_ok = False
+                                        if fail_fast:
+                                            stopped = True
+                                            break
+
+                                if op_ok:
+                                    iter_note = (
+                                        f" across {iterations} iterations"
+                                        if iterations > 1
+                                        else ""
+                                    )
+                                    logger.info(
+                                        f"    PASSED {op_def.name} "
+                                        f"(all {len(self.gpu_ids)} GPUs match"
+                                        f"{iter_note})"
+                                    )
+
+                    # Dtype-based modes run once (dtype is fixed by mode)
+                    if pmode in ("fp16", "bf16", "fp8"):
+                        break
+
+            # --- Pipeline tests ---
+            if run_pipelines and PIPELINE_REGISTRY and not stopped:
+                for pmode in precision_modes:
+                    if stopped:
+                        break
+                    set_precision_mode(pmode)
+                    mode_dtype = resolve_dtype(pmode)
+                    self.current_dtype = (
+                        mode_dtype
+                        if pmode in ("fp16", "bf16", "fp8")
+                        else resolved_dtypes[0]
+                    )
+                    pmode_label = pmode.upper()
+                    logger.info(f"--- Pipeline Tests ({pmode_label}) ---")
+                    pipeline_size = (1024, 1024)
+
+                    for _pidx, pipeline_def in enumerate(PIPELINE_REGISTRY):
+                        if stopped:
+                            break
+                        for it in range(iterations):
+                            results = {}
+                            for gpu_id in self.gpu_ids:
+                                self.device = f"cuda:{gpu_id}"
+                                try:
+                                    enable_deterministic_mode()
+                                    set_precision_mode(pmode)
+                                    operation = pipeline_def.factory(
+                                        self, pipeline_size
+                                    )
+                                    with torch.cuda.device(gpu_id):
+                                        result = operation()
+                                        if isinstance(result, torch.Tensor):
+                                            results[gpu_id] = (result.cpu(), None)
+                                except RuntimeError as e:
+                                    if "out of memory" in str(e):
+                                        logger.warning(
+                                            f"  GPU {gpu_id}: OOM on pipeline - skipping"
+                                        )
+                                        torch.cuda.empty_cache()
+                                    else:
+                                        raise
+                                finally:
+                                    torch.cuda.empty_cache()
+
+                            total += 1
+                            plabel = f"[Pipeline] {pipeline_def.name}"
+                            if len(precision_modes) > 1:
+                                plabel = f"{plabel} [{pmode_label}]"
+                            if iterations > 1:
+                                plabel = f"{plabel} iter {it + 1}/{iterations}"
+                            if self._compare_cross_gpu(
+                                plabel,
+                                results,
+                                verbose=verbose,
+                            ):
+                                passed += 1
+                            else:
+                                if fail_fast:
+                                    stopped = True
+                                    break
+
+                        if not stopped:
+                            check_label = f"[Pipeline] {pipeline_def.name}"
+                            if len(precision_modes) > 1:
+                                check_label = f"{check_label} [{pmode_label}]"
+                            pipeline_failed = any(
+                                check_label in f for f in self._failures
+                            )
+                            if not pipeline_failed:
+                                mode_note = (
+                                    f" [{pmode_label}]"
+                                    if len(precision_modes) > 1
+                                    else ""
+                                )
+                                logger.info(
+                                    f"    PASSED [Pipeline] {pipeline_def.name} "
+                                    f"(all GPUs match{mode_note})"
+                                )
+
+        except _TimeLimitReached:
+            time_limited = True
+            logger.info(f"\nDuration limit ({duration_limit}s) reached — hard stop")
+        finally:
+            if duration_limit is not None:
+                signal.alarm(0)
+                if old_handler is not None:
+                    signal.signal(signal.SIGALRM, old_handler)
+
+        elapsed = time.time() - start_time
+        # Use len(self._failures) rather than total-passed: if SIGALRM fires
+        # after total+=1 but before _compare_cross_gpu completes, total-passed
+        # would be 1 with an empty failures list (false positive FAIL result).
+        failed = len(self._failures)
+        all_peers_disagree = self._is_all_peers_disagree()
+        self._log_summary(
+            elapsed, total, passed, failed, stopped, time_limited, all_peers_disagree
+        )
+        self._all_peers_disagree = all_peers_disagree
+
+        if all_peers_disagree:
+            passed = total
+            failed = 0
+            self._failures.clear()
+
+        return {
+            "total_comparisons": total,
+            "passed": passed,
+            "failed": failed,
+            "elapsed_seconds": round(elapsed, 2),
+            "time_limited": time_limited,
+            "max_diff": self._run_max_diff,
+            "total_mismatched": self._run_total_mismatched,
+            "total_elements": self._run_total_elements,
+            "failures": list(self._failures),
+            "all_peers_disagree": self._all_peers_disagree,
+            "gpu_disagreements": {
+                g: sorted(peers) for g, peers in self._gpu_disagreements.items()
+            },
+        }
+
+    def _is_all_peers_disagree(self) -> bool:
+        """Check if every GPU disagrees with every other GPU.
+
+        When all GPUs show max disagreement (N-1 out of N-1 peers),
+        it indicates a systemic issue (e.g., non-determinism, driver
+        bug, library mismatch) rather than a single bad GPU.  Real SDC
+        has one GPU disagreeing with all others while the rest agree
+        among themselves.
+
+        Requires N >= 3 GPUs. With only 2 GPUs (n_peers=1), both a
+        single bad GPU and a systemic issue look identical — every GPU
+        shows 1/1 peer disagreement — so we cannot distinguish them and
+        conservatively report as SDC.
+        """
+        n_peers = len(self.gpu_ids) - 1
+        if n_peers < 2:
+            return False
+        return all(
+            len(self._gpu_disagreements.get(g, set())) == n_peers for g in self.gpu_ids
+        )
+
+    def _log_summary(
+        self,
+        elapsed: float,
+        total: int,
+        passed: int,
+        failed: int,
+        stopped: bool,
+        time_limited: bool = False,
+        all_peers_disagree: bool = False,
+    ) -> None:
+        """Print the final per-GPU summary."""
+        if self._failures:
+            n_peers = len(self.gpu_ids) - 1
+
+            if all_peers_disagree:
+                logger.warning(
+                    "\nALL GPUs DISAGREE — systemic issue, not SDC. "
+                    "Every GPU produced different results, which indicates "
+                    "non-determinism, driver bug, or library mismatch rather "
+                    "than a single faulty GPU."
+                )
+                logger.warning(
+                    f"  {len(self._failures)} comparison(s) failed across "
+                    f"{len(self.gpu_ids)} GPUs in {elapsed:.1f}s"
+                )
+                return
+
+            logger.error("\nSDC Summary:")
+            for gpu_id in sorted(self.gpu_ids):
+                serial = self._gpu_serials.get(gpu_id, "unknown")
+                serial_str = f" [S/N: {serial}]" if serial != "unknown" else ""
+                n_disagree = len(self._gpu_disagreements.get(gpu_id, set()))
+                if n_disagree > 0:
+                    label = f"FAIL ({n_disagree}/{n_peers} peers disagree)"
+                    if n_disagree == n_peers:
+                        label += " <-- BAD GPU"
+                    logger.error(f"  GPU {gpu_id}{serial_str}: {label}")
+                else:
+                    logger.info(
+                        f"  GPU {gpu_id}{serial_str}: PASS (0/{n_peers} peers disagree)"
+                    )
+
+            if stopped and not time_limited:
+                logger.error(
+                    f"\nSDC DETECTED -- stopped after first failure "
+                    f"({passed} passed before failure, {elapsed:.1f}s)"
+                )
+            elif time_limited:
+                logger.error(
+                    f"\nCROSS-GPU SDC DETECTED: {len(self._failures)} failures "
+                    f"in {total} comparisons across {len(self.gpu_ids)} GPUs "
+                    f"({elapsed:.1f}s) (time-limited)"
+                )
+            else:
+                logger.error(
+                    f"\nCROSS-GPU SDC DETECTED: {len(self._failures)} failures "
+                    f"in {total} comparisons across {len(self.gpu_ids)} GPUs "
+                    f"({elapsed:.1f}s)"
+                )
+        else:
+            suffix = " (time-limited)" if time_limited else ""
+            logger.info(
+                f"\nALL CROSS-GPU TESTS PASSED - "
+                f"{total} comparisons across {len(self.gpu_ids)} GPUs "
+                f"in {elapsed:.1f}s{suffix}"
+            )

--- a/pytorch_op/detector.py
+++ b/pytorch_op/detector.py
@@ -1,0 +1,334 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""GPU SDC Detector for PyTorch operator-level testing.
+
+Standalone class that runs registered ops multiple times with deterministic
+settings and compares outputs for bit-exact reproducibility.
+"""
+
+import logging
+import random
+import time
+from collections import OrderedDict
+from typing import Callable, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from .ops import DTYPE_MAP, OP_REGISTRY, OpDef, PIPELINE_REGISTRY
+
+logger = logging.getLogger("pytorch_op_test")
+
+
+class GPUSDCDetector:
+    """Detects Silent Data Corruption by checking op determinism on GPU."""
+
+    # Default tensor sizes: progressive memory coverage.
+    # Use --sizes for custom shapes (e.g. rectangular: 1024x16384).
+    DEFAULT_SIZES = [
+        (1024, 1024),
+        (4096, 4096),
+        (8192, 8192),
+    ]
+
+    def __init__(
+        self,
+        gpu_id: int = 0,
+        num_iterations: int = 3,
+        test_sizes: Optional[List[Tuple[int, int]]] = None,
+    ):
+        self.gpu_id = gpu_id
+        self.num_iterations = num_iterations
+        self.current_dtype = torch.float32
+        self.device = f"cuda:{gpu_id}"
+        self._failed_operations: List[str] = []
+        self._test_sizes = test_sizes or self.DEFAULT_SIZES
+
+    def create_test_tensor(
+        self, shape: Tuple[int, ...], dtype: Optional[torch.dtype] = None
+    ) -> torch.Tensor:
+        """Create a test tensor on the GPU with fixed seed."""
+        dtype = dtype or self.current_dtype
+        torch.manual_seed(42)
+        if dtype in (torch.float16, torch.bfloat16):
+            return torch.randn(shape, dtype=torch.float32, device=self.device).to(dtype)
+        return torch.randn(shape, dtype=dtype, device=self.device)
+
+    def _resolve_dtypes(self, dtypes: Optional[List[str]]) -> List[torch.dtype]:
+        """Validate and resolve dtype strings to torch.dtype objects."""
+        if dtypes is None:
+            dtypes = ["float32"]
+        resolved = []
+        for dt_name in dtypes:
+            dt_name = dt_name.strip()
+            if dt_name not in DTYPE_MAP:
+                raise ValueError(
+                    f"Unknown dtype: {dt_name}. "
+                    f"Available: {', '.join(DTYPE_MAP.keys())}"
+                )
+            resolved.append(DTYPE_MAP[dt_name])
+        return resolved
+
+    def _check_gpu(self):
+        """Validate that the target GPU is available."""
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+        if self.gpu_id >= torch.cuda.device_count():
+            raise RuntimeError(
+                f"GPU {self.gpu_id} not found. Available: {torch.cuda.device_count()}"
+            )
+
+    def _run_op_tests(
+        self, categories: Optional[List[str]], resolved_dtypes: List[torch.dtype]
+    ) -> Tuple[int, int]:
+        """Run all registered op tests across dtypes and sizes. Returns (total, passed)."""
+        total_ops = 0
+        passed_ops = 0
+        for dtype in resolved_dtypes:
+            self.current_dtype = dtype
+            if len(resolved_dtypes) > 1:
+                logger.info(f"Testing dtype: {dtype}")
+            for size in self._test_sizes:
+                logger.info(f"Testing with tensor size: {size}")
+                for category, ops in self._get_ops_by_category(categories):
+                    cat_label = category.replace("_", " ").title()
+                    logger.info(f"--- {cat_label} Operations ---")
+                    for op_def in ops:
+                        operation = op_def.factory(self, size)
+                        total_ops += 1
+                        if self._test_operation(op_def.name, operation):
+                            passed_ops += 1
+        return total_ops, passed_ops
+
+    def _run_pipeline_tests(self) -> Tuple[int, int]:
+        """Run composite pipeline tests. Returns (total, passed)."""
+        total_ops = 0
+        passed_ops = 0
+        logger.info("--- Composite Pipeline Tests ---")
+        size = (1024, 1024)
+        for pipeline_def in PIPELINE_REGISTRY:
+            operation = pipeline_def.factory(self, size)
+            total_ops += 1
+            if self._test_operation(f"[Pipeline] {pipeline_def.name}", operation):
+                passed_ops += 1
+        return total_ops, passed_ops
+
+    def _log_results(self, total_ops: int, elapsed: float):
+        """Log final pass/fail summary."""
+        if self._failed_operations:
+            logger.error(
+                f"FAILED: {len(self._failed_operations)} operation(s) showed corruption"
+            )
+            for i, op in enumerate(self._failed_operations, 1):
+                logger.error(f"  {i}. {op}")
+            logger.error(f"GPU {self.gpu_id} is producing non-deterministic results")
+        else:
+            logger.info(
+                f"ALL TESTS PASSED - GPU {self.gpu_id} deterministic across "
+                f"{total_ops} operations in {elapsed:.1f}s"
+            )
+
+    def run_all_tests(
+        self,
+        categories: Optional[List[str]] = None,
+        dtypes: Optional[List[str]] = None,
+        run_pipelines: bool = False,
+    ) -> dict:
+        """Run all registered op tests and return results dict.
+
+        Returns:
+            dict with keys: ops_total, ops_passed, ops_failed,
+            elapsed_seconds, failed_operations
+        """
+        resolved_dtypes = self._resolve_dtypes(dtypes)
+        self._check_gpu()
+        self._enable_deterministic_mode()
+
+        logger.info(
+            f"Testing GPU {self.gpu_id}: {torch.cuda.get_device_name(self.gpu_id)}"
+        )
+        logger.info(f"Iterations per operation: {self.num_iterations}")
+
+        start_time = time.time()
+        self._failed_operations = []
+
+        total_ops, passed_ops = self._run_op_tests(categories, resolved_dtypes)
+
+        if run_pipelines and PIPELINE_REGISTRY:
+            self.current_dtype = resolved_dtypes[0]
+            pipe_total, pipe_passed = self._run_pipeline_tests()
+            total_ops += pipe_total
+            passed_ops += pipe_passed
+
+        elapsed = time.time() - start_time
+        self._log_results(total_ops, elapsed)
+
+        return {
+            "ops_total": total_ops,
+            "ops_passed": passed_ops,
+            "ops_failed": len(self._failed_operations),
+            "elapsed_seconds": round(elapsed, 2),
+            "failed_operations": list(self._failed_operations),
+        }
+
+    def _enable_deterministic_mode(self):
+        """Enable deterministic settings for reproducible results."""
+        seed = 42
+        torch.manual_seed(seed)
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    def _run_operation_on_gpu(self, operation: Callable) -> torch.Tensor:
+        """Run an operation on the GPU and return result on CPU."""
+        with torch.cuda.device(self.gpu_id):
+            result = operation()
+            if isinstance(result, torch.Tensor):
+                return result.cpu()
+            return result
+
+    def _test_operation(self, op_name: str, operation: Callable) -> bool:
+        """Test an operation by running it multiple times and comparing."""
+        try:
+            outputs = []
+            for _ in range(self.num_iterations):
+                self._enable_deterministic_mode()
+                output = self._run_operation_on_gpu(operation)
+                outputs.append(output)
+
+            return self._compare_outputs(outputs, op_name)
+        except Exception as e:
+            logger.error(f"EXCEPTION in {op_name}: {str(e)}")
+            self._failed_operations.append(op_name)
+            return False
+
+    def _compare_outputs(self, outputs: List[torch.Tensor], op_name: str) -> bool:
+        """Compare multiple outputs from the same operation."""
+        reference = outputs[0]
+
+        for _i, output in enumerate(outputs[1:], start=1):
+            if output.shape != reference.shape:
+                logger.error(f"SHAPE MISMATCH in {op_name}")
+                self._failed_operations.append(op_name)
+                return False
+
+            # Bit-exact comparison — any difference at all is SDC.
+            # Use NaN-aware comparison: IEEE 754 says NaN != NaN, so
+            # torch.equal returns False when both tensors have NaN in
+            # the same positions.  Treat matching NaN positions as equal.
+            nan_ref = torch.isnan(reference)
+            nan_out = torch.isnan(output)
+            has_nan = nan_ref.any() or nan_out.any()
+            if has_nan:
+                nan_positions_match = torch.equal(nan_ref, nan_out)
+                non_nan = ~nan_ref
+                non_nan_equal = not non_nan.any() or torch.equal(
+                    reference[non_nan], output[non_nan]
+                )
+                tensors_equal = nan_positions_match and non_nan_equal
+            else:
+                tensors_equal = torch.equal(reference, output)
+
+            if not tensors_equal:
+                # Upcast to float32 only for the detailed mismatch report
+                ref_f32 = reference.float()
+                out_f32 = output.float()
+                diff = torch.abs(ref_f32 - out_f32)
+                # Mask NaN positions so they don't poison stats
+                nan_mask = torch.isnan(diff)
+                if nan_mask.any():
+                    diff = diff.clone()
+                    diff[nan_mask] = 0.0
+                mismatches = int((diff > 0).sum().item())
+                total = reference.numel()
+                max_diff = diff.max().item()
+                logger.error(
+                    f"CORRUPTION DETECTED in {op_name}: "
+                    f"max_diff={max_diff:.2e}, "
+                    f"mismatched={mismatches}/{total} "
+                    f"({100 * mismatches / total:.2f}%)"
+                )
+                self._print_detailed_mismatch(ref_f32, out_f32, diff, op_name)
+                self._failed_operations.append(op_name)
+                return False
+
+        logger.info(
+            f"PASSED {op_name} (all {self.num_iterations} iterations identical)"
+        )
+        return True
+
+    def _print_detailed_mismatch(
+        self,
+        reference: torch.Tensor,
+        output: torch.Tensor,
+        diff: torch.Tensor,
+        op_name: str,
+    ):
+        """Print detailed information about the mismatch."""
+        max_diff_idx = diff.argmax()
+        max_diff_pos = np.unravel_index(max_diff_idx.item(), diff.shape)
+
+        logger.error(f"  Location of max difference: {max_diff_pos}")
+        logger.error(f"  Expected: {reference.flatten()[max_diff_idx].item():.10e}")
+        logger.error(f"  Actual:   {output.flatten()[max_diff_idx].item():.10e}")
+
+        num_samples = min(10, diff.numel())
+        top_diffs = torch.topk(diff.flatten(), num_samples)
+        logger.error(f"  Top {num_samples} mismatched values:")
+        for idx in top_diffs.indices:
+            pos = np.unravel_index(idx.item(), diff.shape)
+            logger.error(
+                f"    {pos}: "
+                f"expected={reference.flatten()[idx].item():.10e}, "
+                f"actual={output.flatten()[idx].item():.10e}, "
+                f"diff={diff.flatten()[idx].item():.10e}"
+            )
+
+        logger.error(
+            f"  Reference: mean={reference.mean().item():.6e}, "
+            f"std={reference.std().item():.6e}"
+        )
+        logger.error(
+            f"  Corrupted: mean={output.mean().item():.6e}, "
+            f"std={output.std().item():.6e}"
+        )
+
+    def _get_ops_by_category(
+        self, categories: Optional[List[str]] = None
+    ) -> List[Tuple[str, List[OpDef]]]:
+        """Return ops grouped by category, preserving registration order."""
+        grouped: OrderedDict[str, List[OpDef]] = OrderedDict()
+        for op_def in OP_REGISTRY:
+            if categories and op_def.category not in categories:
+                continue
+            grouped.setdefault(op_def.category, []).append(op_def)
+        return list(grouped.items())
+
+    def list_ops(self):
+        """Print all registered ops grouped by category."""
+        grouped: OrderedDict[str, List[str]] = OrderedDict()
+        for op_def in OP_REGISTRY:
+            grouped.setdefault(op_def.category, []).append(op_def.name)
+
+        print("Registered operations:\n")
+        total = 0
+        for category, names in grouped.items():
+            cat_label = category.replace("_", " ").title()
+            print(f"  {cat_label} ({len(names)}):")
+            for name in names:
+                print(f"    - {name}")
+            total += len(names)
+            print()
+
+        print(f"Total: {total} operations across {len(grouped)} categories")
+
+        if PIPELINE_REGISTRY:
+            print(f"\nComposite pipelines ({len(PIPELINE_REGISTRY)}):")
+            for p in PIPELINE_REGISTRY:
+                print(f"    - {p.name}")
+
+        print(f"\nAvailable categories: {', '.join(grouped.keys())}")
+        print(f"Available dtypes: {', '.join(DTYPE_MAP.keys())}")

--- a/pytorch_op/main.py
+++ b/pytorch_op/main.py
@@ -1,0 +1,770 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Unified entry point for PyTorch operator-level SDC detection.
+
+Modes:
+  self       - Self-consistency on a single GPU (original behavior)
+  cross-gpu  - Cross-GPU operator comparison (recommended for SDC detection)
+  sweep      - Systematic HBM region coverage via staircase operator tests
+
+Presets (for cross-gpu mode, override --iterations/--sizes/--categories):
+  quick      - 1 iter, all ops, 4kx4k, hash-inputs                  (~1-2 min)
+  standard   - 3 iters, all ops+pipelines, 4kx4k, hash-inputs      (~5 min)
+  thorough   - 10 iters, all ops+pipelines, 4kx4k + sweep           (~25-30 min)
+
+Memory warmup is automatic: each cross-gpu run randomizes warmup between
+0% and a calculated max (leaving room for test tensors + CUDA overhead).
+This varies which HBM regions are tested across runs. Sweep mode manages
+memory deterministically via staircase allocation.
+
+By default, runs all ops to completion and prints a per-GPU summary
+identifying bad GPU(s). Use --fail-fast to stop on first failure,
+--verbose/-v for full element-level detail.
+
+Usage:
+  python -m pytorch_op.main --preset quick               All GPUs, quick check
+  python -m pytorch_op.main --preset quick --fail-fast    Stop on first failure
+  python -m pytorch_op.main --preset quick -v             Full detail on failures
+  python -m pytorch_op.main --mode sweep                  Systematic full-HBM scan
+  python -m pytorch_op.main --mode self                   Self-test all GPUs
+  python -m pytorch_op.main --mode cross-gpu --hash-inputs  Cross-GPU, all GPUs
+  python -m pytorch_op.main --mode cross-gpu --precision-modes tf32  Test matrix cores
+  python -m pytorch_op.main --preset standard --duration-limit 120   Hard stop after 2 min
+  python -m pytorch_op.main --list-ops
+"""
+
+import argparse
+import logging
+import os
+import random
+import sys
+
+logger = logging.getLogger("pytorch_op")
+
+# Preset configurations for cross-gpu mode
+PRESETS = {
+    "quick": {
+        "iterations": 1,
+        "sizes": [(4096, 4096)],
+        "categories": None,  # all
+        "hash_inputs": True,
+        "pipelines": False,
+    },
+    "standard": {
+        "iterations": 3,
+        "sizes": [(4096, 4096)],
+        "categories": None,  # all
+        "hash_inputs": True,
+        "pipelines": True,
+    },
+    "thorough": {
+        "iterations": 10,
+        "sizes": [(4096, 4096)],
+        "categories": None,  # all
+        "hash_inputs": True,
+        "pipelines": True,
+        "sweep": True,
+        "sweep_chunk_gb": 8.0,
+    },
+}
+
+
+def _parse_sizes(sizes_str):
+    """Parse comma-separated size specs like '4096x4096,14000x14000'."""
+    sizes = []
+    for s in sizes_str.split(","):
+        s = s.strip()
+        if "x" in s:
+            parts = s.split("x")
+            sizes.append((int(parts[0]), int(parts[1])))
+        else:
+            n = int(s)
+            sizes.append((n, n))
+    return sizes
+
+
+def _get_gpu_ids():
+    """Return all GPU IDs on the box."""
+    import torch
+
+    return list(range(torch.cuda.device_count()))
+
+
+def _random_warmup(gpu_ids, test_sizes, element_size=4):
+    """Randomize memory warmup to vary which HBM regions are tested.
+
+    Each run allocates a random amount of GPU memory (0% to max safe %)
+    before testing. This varies which HBM addresses test tensors land in,
+    improving coverage across multiple runs.
+
+    Max warmup is calculated dynamically:
+      max_warmup = free_mem - (2 * largest_tensor) - cuda_overhead
+
+    This leaves room for 2x the largest test tensor (input + output) plus
+    buffer for CUDA context/workspace. Adapts to actual GPU memory and
+    test config — no hardcoded percentages.
+
+    Sweep mode does NOT use warmup — it manages memory deterministically
+    via staircase allocation.
+    """
+    import torch
+
+    # Largest tensor in bytes from test config
+    max_elements = max(m * n for m, n in test_sizes)
+    largest_tensor_bytes = max_elements * element_size
+    # Reserve enough free memory for test ops to run without OOM.
+    # Backward ops and pipelines allocate multiple large intermediates
+    # (activations, gradients, optimizer state), so we need more than
+    # just 2x the test tensor. Use at least 4 GB for op execution.
+    op_buffer = max(2 * largest_tensor_bytes, 4 * (1024**3))
+    # CUDA overhead: cuBLAS workspace, RNG state, caching allocator metadata
+    cuda_overhead = 2 * (1024**3)  # 2 GB
+
+    # Use min free memory across GPUs to determine safe max
+    min_free = min(torch.cuda.mem_get_info(g)[0] for g in gpu_ids)
+    max_warmup = max(0, min_free - op_buffer - cuda_overhead)
+
+    if max_warmup == 0:
+        logger.info("Warmup: not enough free memory, skipping")
+        return {}
+
+    # Same random amount for all GPUs (tests same HBM depth)
+    warmup_bytes = random.randint(0, int(max_warmup))
+    total_mem = torch.cuda.get_device_properties(gpu_ids[0]).total_memory
+    warmup_pct = warmup_bytes / total_mem * 100
+    max_pct = max_warmup / total_mem * 100
+
+    logger.info(
+        f"Warmup: {warmup_pct:.1f}% "
+        f"({warmup_bytes / 1e9:.1f} / {total_mem / 1e9:.1f} GB, "
+        f"max {max_pct:.1f}%)"
+    )
+
+    held_tensors = {}
+    chunk_elements = 256 * 1024 * 1024  # 1GB chunks in float32
+    for gpu_id in gpu_ids:
+        device = f"cuda:{gpu_id}"
+        tensors = []
+        allocated = 0
+        while allocated < warmup_bytes:
+            remaining = warmup_bytes - allocated
+            n_elements = min(chunk_elements, remaining // 4)
+            if n_elements <= 0:
+                break
+            try:
+                t = torch.randn(n_elements, device=device)
+                tensors.append(t)
+                allocated += n_elements * 4
+            except torch.cuda.OutOfMemoryError:
+                break
+        held_tensors[gpu_id] = tensors
+        logger.info(
+            f"  GPU {gpu_id}: {allocated / 1e9:.1f} GB allocated, "
+            f"{torch.cuda.mem_get_info(gpu_id)[0] / 1e9:.1f} GB free"
+        )
+
+    return held_tensors
+
+
+def _sweep_cross_gpu(args, preset=None):
+    """Run cross-GPU operator tests with systematic HBM coverage.
+
+    Staircase approach — progressively fills GPU memory, testing each new
+    region before filling it:
+    1. Run operator tests with no fill → tensors land in lowest region
+    2. Fill region 0 (hold chunk), run tests → tensors land in region 1
+    3. Fill region 1 (hold chunk), run tests → tensors land in region 2
+    4. Continue until GPU memory is exhausted
+
+    Why staircase instead of sliding-window:
+    Filling ALL memory at once forces CUDA internals (cuBLAS workspace,
+    RNG state, caching allocator metadata) into corrupted HBM regions,
+    which taints every subsequent operation regardless of where test tensors
+    land. The staircase avoids this by never filling beyond the current
+    test boundary — CUDA internals stay in the earliest (typically clean)
+    regions.
+    """
+    import torch
+
+    from .cross_gpu import CrossGPUDetector
+
+    # Resolve config from preset
+    iterations = args.iterations
+    test_sizes = _parse_sizes(args.sizes) if args.sizes else None
+    categories = None
+    if args.categories:
+        categories = [c.strip() for c in args.categories.split(",")]
+    hash_inputs = args.hash_inputs
+    run_pipelines = args.pipelines
+
+    if preset:
+        cfg = PRESETS[preset]
+        if args.iterations == 1:
+            iterations = cfg["iterations"]
+        if test_sizes is None:
+            test_sizes = cfg["sizes"]
+        if categories is None:
+            categories = cfg["categories"]
+        hash_inputs = hash_inputs or cfg["hash_inputs"]
+        run_pipelines = run_pipelines or cfg["pipelines"]
+
+    gpu_ids = _get_gpu_ids()
+    if len(gpu_ids) < 2:
+        # Sweep requires cross-GPU comparison — skip gracefully on single-GPU
+        # platforms (e.g. Grace Hopper GH200) to avoid false SDC reports.
+        logger.info(
+            f"{len(gpu_ids)} GPU(s) detected — skipping sweep mode "
+            "(requires 2+ GPUs for cross-GPU comparison)"
+        )
+        return 0
+
+    dtypes = [d.strip() for d in args.dtypes.split(",")]
+    sweep_chunk_gb = args.sweep_chunk_gb
+    chunk_elements = int(sweep_chunk_gb * 1e9 / 4)  # float32 = 4 bytes
+
+    # Determine how many regions we can test
+    free_mem = min(torch.cuda.mem_get_info(g)[0] for g in gpu_ids)
+    n_regions = int(free_mem / (sweep_chunk_gb * 1e9))
+    if n_regions == 0:
+        print("ERROR: not enough free GPU memory for sweep", file=sys.stderr)
+        return 1
+
+    logger.info(
+        f"Sweep: staircase through ~{n_regions} x {sweep_chunk_gb} GB regions "
+        f"({n_regions * sweep_chunk_gb:.0f} GB per GPU)"
+    )
+    logger.info(f"Sweep: testing {n_regions} memory regions...\n")
+
+    # Staircase: progressively fill memory, testing each new region
+    held_chunks = {gpu_id: [] for gpu_id in gpu_ids}  # keep alive
+    overall_failed = 0
+    overall_passed = 0
+    region_results = []
+
+    for i in range(n_regions):
+        region_start = i * sweep_chunk_gb
+        region_end = (i + 1) * sweep_chunk_gb
+
+        logger.info(
+            f"--- Sweep region {i + 1}/{n_regions} "
+            f"(~{region_start:.0f}-{region_end:.0f} GB offset) ---"
+        )
+
+        # Run operator tests — tensors land in the next free region
+        detector = CrossGPUDetector(
+            gpu_ids=gpu_ids,
+            test_sizes=test_sizes,
+            hash_inputs=hash_inputs,
+        )
+
+        result = detector.run(
+            categories=categories,
+            dtypes=dtypes,
+            iterations=iterations,
+            run_pipelines=run_pipelines,
+            fail_fast=args.fail_fast,
+            verbose=args.verbose,
+            precision_modes=args.precision_modes,
+            duration_limit=args.duration_limit,
+        )
+
+        overall_passed += result["passed"]
+        overall_failed += result["failed"]
+
+        status = "FAIL" if result["failed"] > 0 else "PASS"
+        region_results.append(
+            (i, region_start, region_end, status, result["passed"], result["failed"])
+        )
+
+        if result.get("time_limited"):
+            logger.info(f"  Region {i + 1}/{n_regions}: duration limit reached")
+            break
+
+        if result["failed"] > 0:
+            logger.error(
+                f"  Region {i + 1}/{n_regions}: SDC DETECTED "
+                f"({result['failed']} failures)"
+            )
+            if args.fail_fast:
+                break
+        else:
+            logger.info(
+                f"  Region {i + 1}/{n_regions}: PASSED "
+                f"({result['passed']} comparisons clean)"
+            )
+
+        # Fill this region on all GPUs so next iteration's tensors
+        # land in the next region
+        for gpu_id in gpu_ids:
+            device = f"cuda:{gpu_id}"
+            try:
+                t = torch.randn(chunk_elements, device=device)
+                held_chunks[gpu_id].append(t)
+            except torch.cuda.OutOfMemoryError:
+                # Out of memory — we've tested all available regions
+                logger.info(f"  GPU {gpu_id}: OOM at region {i + 1}, ending sweep")
+                break
+        else:
+            # Only continue if all GPUs allocated successfully
+            continue
+        break  # OOM on at least one GPU
+
+    # Summary
+    actual_regions = len(region_results)
+    logger.info(f"\n{'=' * 60}")
+    logger.info("SWEEP REGION SUMMARY:")
+    for idx, start, end, status, passed, failed in region_results:
+        marker = "FAIL" if status == "FAIL" else "PASS"
+        logger.info(
+            f"  Region {idx + 1} (~{start:.0f}-{end:.0f} GB): {marker} "
+            f"({passed} passed, {failed} failed)"
+        )
+
+    if overall_failed > 0:
+        logger.error(
+            f"\nSWEEP SDC DETECTED: {overall_failed} failures across "
+            f"{actual_regions} memory regions ({overall_passed} passed)"
+        )
+    else:
+        logger.info(
+            f"\nSWEEP PASSED: {overall_passed} comparisons clean across "
+            f"{actual_regions} memory regions"
+        )
+    logger.info(f"{'=' * 60}")
+
+    print(
+        f"\nResult: {{'sweep_regions': {actual_regions}, "
+        f"'total_passed': {overall_passed}, "
+        f"'total_failed': {overall_failed}}}"
+    )
+
+    # Cleanup
+    del held_chunks
+    torch.cuda.empty_cache()
+
+    return 1 if overall_failed > 0 else 0
+
+
+def _run_self_mode(args):
+    """Run self-consistency testing on each GPU in parallel."""
+    from concurrent.futures import as_completed, ThreadPoolExecutor
+
+    from .detector import GPUSDCDetector
+
+    gpu_ids = _get_gpu_ids()
+    test_sizes = _parse_sizes(args.sizes) if args.sizes else None
+
+    if args.list_ops:
+        detector = GPUSDCDetector(test_sizes=test_sizes)
+        detector.list_ops()
+        return 0
+
+    categories = None
+    if args.categories:
+        categories = [c.strip() for c in args.categories.split(",")]
+
+    dtypes = [d.strip() for d in args.dtypes.split(",")]
+
+    def _test_gpu(gpu_id):
+        detector = GPUSDCDetector(
+            gpu_id=gpu_id,
+            num_iterations=args.iterations,
+            test_sizes=test_sizes,
+        )
+        try:
+            result = detector.run_all_tests(
+                categories=categories,
+                dtypes=dtypes,
+                run_pipelines=args.pipelines,
+            )
+            result["gpu_id"] = gpu_id
+            return result
+        except (ValueError, RuntimeError) as e:
+            return {"gpu_id": gpu_id, "error": str(e)}
+
+    all_results = []
+    overall_rc = 0
+
+    if len(gpu_ids) == 1:
+        # Single GPU — no threading overhead
+        all_results.append(_test_gpu(gpu_ids[0]))
+    else:
+        logger.info(
+            f"Running self-consistency tests on {len(gpu_ids)} GPUs in parallel..."
+        )
+        with ThreadPoolExecutor(max_workers=len(gpu_ids)) as executor:
+            futures = {executor.submit(_test_gpu, g): g for g in gpu_ids}
+            for future in as_completed(futures):
+                all_results.append(future.result())
+
+    # Sort by GPU ID for consistent output
+    all_results.sort(key=lambda r: r["gpu_id"])
+
+    for r in all_results:
+        if "error" in r:
+            print(f"ERROR on GPU {r['gpu_id']}: {r['error']}", file=sys.stderr)
+            overall_rc = 1
+        else:
+            if r["ops_failed"] > 0:
+                overall_rc = 1
+
+    if len(gpu_ids) > 1:
+        logger.info(f"\n{'=' * 60}")
+        logger.info("SELF-CONSISTENCY SUMMARY")
+        logger.info(f"{'=' * 60}")
+        for r in all_results:
+            if "error" in r:
+                logger.error(f"  GPU {r['gpu_id']}: ERROR ({r['error']})")
+            else:
+                status = "FAIL" if r["ops_failed"] > 0 else "PASS"
+                logger.info(
+                    f"  GPU {r['gpu_id']}: {status} "
+                    f"({r['ops_passed']}/{r['ops_total']} passed)"
+                )
+
+    for r in all_results:
+        print(f"\nResult (GPU {r['gpu_id']}): {r}")
+
+    return overall_rc
+
+
+def _run_cross_gpu_mode(args, preset=None):
+    """Run cross-GPU operator comparison."""
+    from .cross_gpu import CrossGPUDetector
+
+    # Apply preset if specified, with explicit args overriding
+    iterations = args.iterations
+    test_sizes = _parse_sizes(args.sizes) if args.sizes else None
+    categories = None
+    if args.categories:
+        categories = [c.strip() for c in args.categories.split(",")]
+    hash_inputs = args.hash_inputs
+    run_pipelines = args.pipelines
+
+    if preset:
+        cfg = PRESETS[preset]
+        if args.iterations == 1:  # default, not explicitly set
+            iterations = cfg["iterations"]
+        if test_sizes is None:
+            test_sizes = cfg["sizes"]
+        if categories is None:
+            categories = cfg["categories"]
+        hash_inputs = hash_inputs or cfg["hash_inputs"]
+        run_pipelines = run_pipelines or cfg["pipelines"]
+
+    # Determine GPUs
+    gpu_ids = _get_gpu_ids()
+
+    if len(gpu_ids) < 2:
+        if len(gpu_ids) == 0:
+            logger.error("no GPUs detected")
+            return 1
+        # Single-GPU platform (e.g. Grace Hopper GH200) — cross-GPU comparison
+        # is impossible, fall back to self-consistency mode so the GPU still
+        # gets tested and we don't pollute SDC metrics with false failures.
+        logger.info(
+            "Single GPU detected — falling back to self-consistency mode "
+            "(cross-GPU comparison requires 2+ GPUs)"
+        )
+        # Apply preset-enhanced values so self-mode runs at the configured depth.
+        args.iterations = iterations
+        if test_sizes is not None:
+            args.sizes = ",".join(f"{w}x{h}" for w, h in test_sizes)
+        if categories is not None:
+            args.categories = ",".join(categories)
+        args.hash_inputs = hash_inputs
+        args.pipelines = run_pipelines
+        return _run_self_mode(args)
+
+    dtypes = [d.strip() for d in args.dtypes.split(",")]
+
+    # Random warmup: vary which HBM regions are tested each run
+    _held_tensors = _random_warmup(gpu_ids, test_sizes or [(4096, 4096)])
+
+    detector = CrossGPUDetector(
+        gpu_ids=gpu_ids,
+        test_sizes=test_sizes,
+        hash_inputs=hash_inputs,
+    )
+
+    result = detector.run(
+        categories=categories,
+        dtypes=dtypes,
+        iterations=iterations,
+        run_pipelines=run_pipelines,
+        fail_fast=args.fail_fast,
+        verbose=args.verbose,
+        precision_modes=args.precision_modes,
+        duration_limit=args.duration_limit,
+    )
+
+    # Release warmup tensors and return memory to CUDA runtime
+    import torch
+
+    del _held_tensors
+    torch.cuda.empty_cache()
+
+    print(f"\nResult: {result}")
+
+    return 1 if result["failed"] > 0 else 0
+
+
+def _resolve_precision_modes(args, parser):
+    """Validate and resolve precision mode arguments.
+
+    Handles --precision-modes, --randomize-precision, and --no-randomize-precision
+    interactions. When no precision mode is specified, randomizes by default.
+    """
+    from .precision import VALID_PRECISION_MODES
+
+    if args.precision_modes is not None:
+        for pm in args.precision_modes:
+            if pm not in VALID_PRECISION_MODES:
+                parser.error(
+                    f"Invalid precision mode '{pm}'. Valid: {sorted(VALID_PRECISION_MODES)}"
+                )
+
+    if args.precision_modes is not None and args.randomize_precision is not True:
+        # User explicitly chose precision modes — honor them
+        pass
+    elif args.randomize_precision is False:
+        # User explicitly disabled randomization
+        args.precision_modes = ["fp32"]
+    else:
+        # Default behavior: randomize
+        from .randomize import randomize_precision
+
+        args.precision_modes = randomize_precision(
+            current_modes=args.precision_modes or ["fp32"],
+            pool=args.precision_modes,
+        )
+
+
+def _resolve_mode_preset(
+    mode: str | None, preset: str | None
+) -> tuple[str, str | None]:
+    """Resolve the effective (mode, preset) pair from CLI args.
+
+    Honor an explicit --mode even when --preset is also set so callers can
+    compose them (e.g., --mode random --preset standard). --preset alone
+    implies cross-gpu for back-compat.
+    """
+    if mode is None:
+        mode = "cross-gpu" if preset else "self"
+    return mode, preset
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="PyTorch operator-level SDC detection",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+examples:
+  %(prog)s --preset quick                              Quick SDC check, all GPUs (~1-2 min)
+  %(prog)s --preset standard                           Standard check, all GPUs (~5 min)
+  %(prog)s --preset thorough                           Full diagnosis + sweep (~25-30 min)
+  %(prog)s --preset quick --fail-fast                  Stop on first failure
+  %(prog)s --preset quick -v                           Full detail on failures
+  %(prog)s --mode self                                 Self-consistency, all GPUs
+  %(prog)s --mode cross-gpu                            Cross-GPU, all GPUs
+  %(prog)s --mode sweep                                Systematic full-HBM sweep
+  %(prog)s --list-ops                                  List all registered ops
+""",
+    )
+
+    # Mode selection
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["self", "cross-gpu", "sweep"],
+        default=None,
+        help="Test mode: self (single-GPU), cross-gpu (compare across GPUs), "
+        "sweep (systematic HBM region coverage). "
+        "Default: self",
+    )
+    parser.add_argument(
+        "--preset",
+        type=str,
+        choices=list(PRESETS.keys()),
+        default=None,
+        help="Predefined configuration (implies --mode cross-gpu). "
+        "quick (~1-2 min), standard (~5 min), thorough (~25-30 min, includes sweep)",
+    )
+
+    # Op configuration
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=1,
+        help="Iterations per op (default: 1 for cross-gpu, 3 for self)",
+    )
+    parser.add_argument(
+        "--sizes",
+        type=str,
+        default=None,
+        help="Comma-separated tensor sizes (e.g. 4096x4096,14000x14000)",
+    )
+    parser.add_argument(
+        "--categories",
+        type=str,
+        default=None,
+        help="Comma-separated op categories (default: all)",
+    )
+    parser.add_argument(
+        "--dtypes",
+        type=str,
+        default="float32",
+        help="Comma-separated dtypes: float32, float16, bfloat16 (default: float32)",
+    )
+    parser.add_argument(
+        "--pipelines",
+        action="store_true",
+        default=False,
+        help="Also run composite pipeline tests",
+    )
+
+    # Cross-GPU specific
+    parser.add_argument(
+        "--hash-inputs",
+        action="store_true",
+        default=False,
+        help="Hash input tensors to distinguish memory vs compute corruption "
+        "(cross-gpu mode only)",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        default=False,
+        help="Stop on first failure (default: run all ops to completion "
+        "and print per-GPU summary).",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        default=False,
+        help="Print full element-level diffs, byte offsets, sample values "
+        "on failure. Combine with --fail-fast for detailed single-failure output.",
+    )
+
+    # Precision modes
+    parser.add_argument(
+        "--precision-modes",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Hardware precision modes to test. Each exercises a different "
+        "datapath: fp32 (vector ALUs), tf32 (matrix cores), fp16, bf16, fp8. "
+        "Multiple modes run as additive passes. "
+        "When not specified, one mode is randomly selected per run "
+        "(see --no-randomize-precision to disable). "
+        "Example: --precision-modes fp32 tf32",
+    )
+    randomize_group = parser.add_mutually_exclusive_group()
+    randomize_group.add_argument(
+        "--randomize-precision",
+        action="store_true",
+        default=None,
+        dest="randomize_precision",
+        help="Randomly select one precision mode per run from the pool "
+        "(fp32, tf32, fp16, bf16). This is the default when "
+        "--precision-modes is not specified.",
+    )
+    randomize_group.add_argument(
+        "--no-randomize-precision",
+        action="store_false",
+        default=None,
+        dest="randomize_precision",
+        help="Disable precision randomization. Uses fp32 if "
+        "--precision-modes is not specified.",
+    )
+
+    # Sweep mode specific
+    parser.add_argument(
+        "--sweep-chunk-gb",
+        type=float,
+        default=4.0,
+        help="Chunk size for sweep mode in GB (default: 4.0). "
+        "Smaller = more regions tested but slower.",
+    )
+
+    # Utility
+    parser.add_argument(
+        "--duration-limit",
+        type=int,
+        default=None,
+        help="Hard duration limit in seconds. Uses SIGALRM to interrupt "
+        "immediately — no waiting for the current op or GPU kernel to finish. "
+        "Reports all results collected before the cutoff. "
+        "Useful for capping run time in automated pipelines.",
+    )
+    parser.add_argument(
+        "--list-ops",
+        "--list_ops",
+        action="store_true",
+        default=False,
+        dest="list_ops",
+        help="List all registered operations and exit",
+    )
+
+    args = parser.parse_args()
+
+    # Set up logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    # Set CUBLAS workspace config for deterministic mode
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+
+    _resolve_precision_modes(args, parser)
+
+    mode, preset = _resolve_mode_preset(args.mode, args.preset)
+
+    # Handle --list-ops before mode dispatch
+    if args.list_ops:
+        from .detector import GPUSDCDetector
+
+        detector = GPUSDCDetector()
+        detector.list_ops()
+        return 0
+
+    # Set self-mode default iterations if not explicitly changed
+    if mode == "self" and args.iterations == 1:
+        args.iterations = 3
+
+    # Dispatch
+    ran_cross_gpu = False
+    if mode == "self":
+        rc = _run_self_mode(args)
+    elif mode == "cross-gpu":
+        rc = _run_cross_gpu_mode(args, preset=preset)
+        ran_cross_gpu = True
+    elif mode == "sweep":
+        rc = _sweep_cross_gpu(args, preset=preset)
+    else:
+        print(f"Unknown mode: {mode}", file=sys.stderr)
+        rc = 1
+
+    # If preset=thorough, also run sweep for full HBM coverage.
+    # Only applies after cross-gpu mode: sweep is a
+    # cross-GPU comparison and is meaningless after self/sweep modes.
+    # Skip sweep if fail-fast already caught SDC in cross-gpu phase.
+    if preset == "thorough" and ran_cross_gpu and not (rc != 0 and args.fail_fast):
+        logger.info("\n=== Running full-HBM sweep (thorough preset) ===")
+        sweep_chunk_gb = PRESETS["thorough"]["sweep_chunk_gb"]
+        args.sweep_chunk_gb = sweep_chunk_gb
+        # Use minimal config per region — sweep is for coverage, not depth
+        args.iterations = 1
+        args.categories = "backward_pass"
+        args.hash_inputs = True
+        args.pipelines = False
+        sweep_rc = _sweep_cross_gpu(args, preset=None)
+        rc = max(rc, sweep_rc)
+
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytorch_op/ops.py
+++ b/pytorch_op/ops.py
@@ -1,0 +1,2026 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Op registry for PyTorch operator-level SDC detection.
+
+To add a new op, decorate a factory function with @register_op:
+
+    @register_op("MyOp", "my_category")
+    def _my_op(detector, size):
+        def op():
+            a = detector.create_test_tensor(size)
+            return torch.some_op(a)
+        return op
+
+To add a composite pipeline test, use @register_pipeline:
+
+    @register_pipeline("My Pipeline")
+    def _my_pipeline(detector, size):
+        def pipeline():
+            x = detector.create_test_tensor(size)
+            x = torch.op1(x)
+            x = torch.op2(x)
+            return x
+        return pipeline
+"""
+
+import os
+from typing import Callable, List, NamedTuple
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Registry types
+# ---------------------------------------------------------------------------
+
+
+class OpDef(NamedTuple):
+    name: str
+    category: str
+    factory: Callable  # (detector, size) -> callable
+
+
+class PipelineDef(NamedTuple):
+    name: str
+    factory: Callable  # (detector, size) -> callable
+
+
+OP_REGISTRY: List[OpDef] = []
+PIPELINE_REGISTRY: List[PipelineDef] = []
+
+DTYPE_MAP = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
+
+
+def register_op(name: str, category: str):
+    """Decorator to register an op test.
+
+    The decorated function must have signature (detector, size) -> callable,
+    where the returned callable takes no args and returns a torch.Tensor.
+    """
+
+    def decorator(fn):
+        OP_REGISTRY.append(OpDef(name=name, category=category, factory=fn))
+        return fn
+
+    return decorator
+
+
+def register_pipeline(name: str):
+    """Decorator to register a composite pipeline test."""
+
+    def decorator(fn):
+        PIPELINE_REGISTRY.append(PipelineDef(name=name, factory=fn))
+        return fn
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Addition", "arithmetic")
+def _add_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        c = b.create_test_tensor(size)
+        return a + c
+
+    return op
+
+
+@register_op("Multiplication", "arithmetic")
+def _mul_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        c = b.create_test_tensor(size)
+        return a * c
+
+    return op
+
+
+@register_op("Division", "arithmetic")
+def _div_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        c = b.create_test_tensor(size) + 1.0
+        return a / c
+
+    return op
+
+
+@register_op("Subtraction", "arithmetic")
+def _sub_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        c = b.create_test_tensor(size)
+        return a - c
+
+    return op
+
+
+@register_op("Power", "arithmetic")
+def _pow_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.pow(a, 2)
+
+    return op
+
+
+@register_op("Square Root", "arithmetic")
+def _sqrt_op(b, size):
+    def op():
+        a = torch.abs(b.create_test_tensor(size))
+        return torch.sqrt(a)
+
+    return op
+
+
+@register_op("Exponential", "arithmetic")
+def _exp_op(b, size):
+    def op():
+        a = b.create_test_tensor(size) * 0.1
+        return torch.exp(a)
+
+    return op
+
+
+@register_op("Logarithm", "arithmetic")
+def _log_op(b, size):
+    def op():
+        a = torch.abs(b.create_test_tensor(size)) + 1.0
+        return torch.log(a)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Matrix ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Matrix Multiplication (matmul)", "matrix")
+def _matmul_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        c = b.create_test_tensor((size[1], size[0]))
+        return torch.matmul(a, c)
+
+    return op
+
+
+@register_op("Transpose", "matrix")
+def _transpose_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.t()
+
+    return op
+
+
+@register_op("Batch Matrix Multiplication", "matrix")
+def _bmm_op(b, size):
+    def op():
+        batch_size = 32
+        m, n = size[0] // 4, size[1] // 4
+        a = b.create_test_tensor((batch_size, m, n))
+        c = b.create_test_tensor((batch_size, n, m))
+        return torch.bmm(a, c)
+
+    return op
+
+
+@register_op("Matrix Multiplication (mm)", "matrix")
+def _mm_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        c = b.create_test_tensor((size[1], size[0]))
+        return torch.mm(a, c)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Reduction ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Sum", "reduction")
+def _sum_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.sum()
+
+    return op
+
+
+@register_op("Mean", "reduction")
+def _mean_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.mean()
+
+    return op
+
+
+@register_op("Max", "reduction")
+def _max_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.max()
+
+    return op
+
+
+@register_op("Min", "reduction")
+def _min_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.min()
+
+    return op
+
+
+@register_op("Standard Deviation", "reduction")
+def _std_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.std()
+
+    return op
+
+
+@register_op("Variance", "reduction")
+def _var_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.var()
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Activation ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("ReLU", "activation")
+def _relu_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.relu(a)
+
+    return op
+
+
+@register_op("Sigmoid", "activation")
+def _sigmoid_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.sigmoid(a)
+
+    return op
+
+
+@register_op("Tanh", "activation")
+def _tanh_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.tanh(a)
+
+    return op
+
+
+@register_op("Softmax", "activation")
+def _softmax_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.softmax(a, dim=-1)
+
+    return op
+
+
+@register_op("GELU", "activation")
+def _gelu_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.nn.functional.gelu(a)
+
+    return op
+
+
+@register_op("SiLU", "activation")
+def _silu_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.nn.functional.silu(a)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Convolution ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Conv2D", "convolution")
+def _conv2d_op(b, size):
+    def op():
+        x = b.create_test_tensor((16, 64, 32, 32))
+        conv = torch.nn.Conv2d(64, 128, 3, padding=1).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        torch.manual_seed(42)
+        conv.weight.data = torch.randn_like(conv.weight.data)
+        conv.bias.data = torch.randn_like(conv.bias.data)
+        return conv(x)
+
+    return op
+
+
+@register_op("Conv1D", "convolution")
+def _conv1d_op(b, size):
+    def op():
+        x = b.create_test_tensor((32, 64, 128))
+        conv = torch.nn.Conv1d(64, 128, 3, padding=1).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        torch.manual_seed(42)
+        conv.weight.data = torch.randn_like(conv.weight.data)
+        conv.bias.data = torch.randn_like(conv.bias.data)
+        return conv(x)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Memory ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Clone", "memory")
+def _clone_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.clone()
+
+    return op
+
+
+@register_op("Copy", "memory")
+def _copy_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        dst = torch.empty_like(a)
+        dst.copy_(a)
+        return dst
+
+    return op
+
+
+@register_op("Clone Large (14kx14k)", "memory")
+def _clone_large_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        a = torch.randn(14000, 14000, dtype=b.current_dtype, device=b.device)
+        return a.clone()
+
+    return op
+
+
+@register_op("Copy Large (14kx14k)", "memory")
+def _copy_large_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        a = torch.randn(14000, 14000, dtype=b.current_dtype, device=b.device)
+        dst = torch.empty_like(a)
+        dst.copy_(a)
+        return dst
+
+    return op
+
+
+@register_op("Reshape", "memory")
+def _reshape_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.reshape(-1)
+
+    return op
+
+
+@register_op("View", "memory")
+def _view_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.view(-1)
+
+    return op
+
+
+@register_op("Permute", "memory")
+def _permute_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return a.permute(1, 0)
+
+    return op
+
+
+@register_op("Concatenate", "memory")
+def _cat_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        c = b.create_test_tensor(size)
+        return torch.cat([a, c], dim=0)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Normalization ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("LayerNorm", "normalization")
+def _layernorm_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        ln = torch.nn.LayerNorm(size[1]).to(dtype=b.current_dtype, device=b.device)
+        torch.manual_seed(42)
+        ln.weight.data = torch.randn_like(ln.weight.data)
+        ln.bias.data = torch.randn_like(ln.bias.data)
+        return ln(a)
+
+    return op
+
+
+@register_op("BatchNorm2D", "normalization")
+def _batchnorm_op(b, size):
+    def op():
+        x = b.create_test_tensor((32, 64, 32, 32))
+        bn = torch.nn.BatchNorm2d(64).to(dtype=b.current_dtype, device=b.device)
+        bn.eval()
+        torch.manual_seed(42)
+        bn.weight.data = torch.randn_like(bn.weight.data)
+        bn.bias.data = torch.randn_like(bn.bias.data)
+        return bn(x)
+
+    return op
+
+
+@register_op("GroupNorm", "normalization")
+def _groupnorm_op(b, size):
+    def op():
+        x = b.create_test_tensor((16, 64, 32, 32))
+        gn = torch.nn.GroupNorm(8, 64).to(dtype=b.current_dtype, device=b.device)
+        torch.manual_seed(42)
+        gn.weight.data = torch.randn_like(gn.weight.data)
+        gn.bias.data = torch.randn_like(gn.bias.data)
+        return gn(x)
+
+    return op
+
+
+@register_op("RMSNorm", "normalization")
+def _rmsnorm_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        rms = torch.nn.RMSNorm(size[1]).to(dtype=b.current_dtype, device=b.device)
+        torch.manual_seed(42)
+        rms.weight.data = torch.randn_like(rms.weight.data)
+        return rms(a)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Advanced ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Dropout (eval mode)", "advanced")
+def _dropout_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        a = b.create_test_tensor(size)
+        return torch.nn.functional.dropout(a, p=0.5, training=False)
+
+    return op
+
+
+@register_op("Einsum", "advanced")
+def _einsum_op(b, size):
+    def op():
+        a = b.create_test_tensor((128, 256))
+        c = b.create_test_tensor((256, 128))
+        return torch.einsum("ij,jk->ik", a, c)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Attention ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Scaled Dot-Product Attention", "attention")
+def _sdpa_op(b, size):
+    def op():
+        seq_len = min(size[0], 512)
+        q = b.create_test_tensor((4, 8, seq_len, 64))
+        k = b.create_test_tensor((4, 8, seq_len, 64))
+        v = b.create_test_tensor((4, 8, seq_len, 64))
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Scatter / Gather ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Scatter Add", "scatter_gather")
+def _scatter_add_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        src = b.create_test_tensor(size)
+        idx = torch.randint(0, size[0], (size[0], size[1]), device=b.device)
+        out = torch.zeros(size, device=b.device, dtype=b.current_dtype)
+        return out.scatter_add(0, idx, src)
+
+    return op
+
+
+@register_op("Gather", "scatter_gather")
+def _gather_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        a = b.create_test_tensor(size)
+        idx = torch.randint(0, size[0], (size[0], size[1]), device=b.device)
+        return torch.gather(a, 0, idx)
+
+    return op
+
+
+@register_op("Index Select", "scatter_gather")
+def _index_select_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        a = b.create_test_tensor(size)
+        idx = torch.randint(0, size[0], (size[0] // 2,), device=b.device)
+        return torch.index_select(a, 0, idx)
+
+    return op
+
+
+@register_op("Index Add", "scatter_gather")
+def _index_add_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        a = b.create_test_tensor(size)
+        idx = torch.arange(size[0] // 2, device=b.device)
+        src = b.create_test_tensor((size[0] // 2, size[1]))
+        return a.index_add(0, idx, src)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Sorting ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Sort", "sorting")
+def _sort_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.sort(a, dim=-1).values
+
+    return op
+
+
+@register_op("TopK", "sorting")
+def _topk_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.topk(a, k=min(100, size[1]), dim=-1).values
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Embedding ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Embedding", "embedding")
+def _embedding_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        emb = torch.nn.Embedding(10000, size[1]).to(b.device)
+        idx = torch.randint(0, 10000, (32, 128), device=b.device)
+        return emb(idx)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Pooling ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("MaxPool2D", "pooling")
+def _maxpool2d_op(b, size):
+    def op():
+        x = b.create_test_tensor((16, 64, 32, 32))
+        return torch.nn.MaxPool2d(kernel_size=2, stride=2)(x)
+
+    return op
+
+
+@register_op("AvgPool2D", "pooling")
+def _avgpool2d_op(b, size):
+    def op():
+        x = b.create_test_tensor((16, 64, 32, 32))
+        return torch.nn.AvgPool2d(kernel_size=2, stride=2)(x)
+
+    return op
+
+
+@register_op("AdaptiveAvgPool2D", "pooling")
+def _adaptive_avgpool2d_op(b, size):
+    def op():
+        x = b.create_test_tensor((16, 64, 32, 32))
+        return torch.nn.AdaptiveAvgPool2d((1, 1))(x)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Indexing ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("Masked Fill", "indexing")
+def _masked_fill_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        a = b.create_test_tensor(size)
+        mask = torch.randint(0, 2, size, device=b.device, dtype=torch.bool)
+        # Use -1e4 instead of -1e9 to stay within float16 range (~65504)
+        fill_val = -1e4 if b.current_dtype == torch.float16 else -1e9
+        return a.masked_fill(mask, fill_val)
+
+    return op
+
+
+@register_op("Where", "indexing")
+def _where_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        a = b.create_test_tensor(size)
+        c = b.create_test_tensor(size)
+        cond = torch.randint(0, 2, size, device=b.device, dtype=torch.bool)
+        return torch.where(cond, a, c)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Model-specific Linear (nn.Linear) ops
+# ---------------------------------------------------------------------------
+# These test the exact matmul shapes used by cpbench models.
+# Models are dominated by nn.Linear which is matmul+bias -- the dominant
+# compute op in every model. Non-square shapes exercise different GPU
+# kernel tiling strategies than the existing square matmul tests.
+
+
+@register_op("Linear BERT FFN Up (1024->4096)", "model_linear")
+def _linear_bert_ffn_up(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((8192, 1024))
+        linear = torch.nn.Linear(1024, 4096, bias=True).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        linear.bias.data = torch.randn_like(linear.bias.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear BERT FFN Down (4096->1024)", "model_linear")
+def _linear_bert_ffn_down(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((8192, 4096))
+        linear = torch.nn.Linear(4096, 1024, bias=True).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        linear.bias.data = torch.randn_like(linear.bias.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear GPT2 Fused QKV (1280->3840)", "model_linear")
+def _linear_gpt2_qkv(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((8192, 1280))
+        linear = torch.nn.Linear(1280, 3840, bias=True).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        linear.bias.data = torch.randn_like(linear.bias.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear GPT2 FFN Up (1280->5120)", "model_linear")
+def _linear_gpt2_ffn_up(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((8192, 1280))
+        linear = torch.nn.Linear(1280, 5120, bias=True).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        linear.bias.data = torch.randn_like(linear.bias.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear GPT2 FFN Down (5120->1280)", "model_linear")
+def _linear_gpt2_ffn_down(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((8192, 5120))
+        linear = torch.nn.Linear(5120, 1280, bias=True).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        linear.bias.data = torch.randn_like(linear.bias.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear LLaMA SwiGLU Up (1200->11008)", "model_linear")
+def _linear_llama_swiglu_up(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((8192, 1200))
+        linear = torch.nn.Linear(1200, 11008, bias=False).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear LLaMA SwiGLU Down (11008->1200)", "model_linear")
+def _linear_llama_swiglu_down(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((8192, 11008))
+        linear = torch.nn.Linear(11008, 1200, bias=False).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear LLaMA QKV Proj (1200->1200)", "model_linear")
+def _linear_llama_qkv(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((8192, 1200))
+        linear = torch.nn.Linear(1200, 1200, bias=False).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear LSTM Gates (1024->4096)", "model_linear")
+def _linear_lstm_gates(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((32, 1024))
+        linear = torch.nn.Linear(1024, 4096, bias=True).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        linear.bias.data = torch.randn_like(linear.bias.data)
+        return linear(x)
+
+    return op
+
+
+@register_op("Linear AlexNet FC (9216->4096)", "model_linear")
+def _linear_alexnet_fc(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((32, 9216))
+        linear = torch.nn.Linear(9216, 4096, bias=True).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        linear.weight.data = torch.randn_like(linear.weight.data)
+        linear.bias.data = torch.randn_like(linear.bias.data)
+        return linear(x)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Model-specific activation ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("GELU New (GPT-2 tanh approx)", "model_activation")
+def _gelu_new_op(b, size):
+    def op():
+        a = b.create_test_tensor((8192, 5120))
+        # gelu_new: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+        return torch.nn.functional.gelu(a, approximate="tanh")
+
+    return op
+
+
+@register_op("SiLU Large (LLaMA MLP)", "model_activation")
+def _silu_large_op(b, size):
+    def op():
+        a = b.create_test_tensor((8192, 11008))
+        return torch.nn.functional.silu(a)
+
+    return op
+
+
+@register_op("Sigmoid", "model_activation")
+def _sigmoid_model_op(b, size):
+    def op():
+        a = b.create_test_tensor(size)
+        return torch.sigmoid(a)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# RMSNorm op (LLaMA-specific)
+# ---------------------------------------------------------------------------
+
+
+@register_op("RMSNorm Manual (LLaMA)", "model_normalization")
+def _rmsnorm_manual_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((32, 256, 1200))
+        weight = torch.randn(1200, device=b.device, dtype=b.current_dtype)
+        eps = 1e-6
+        variance = x.pow(2).mean(-1, keepdim=True)
+        x_normed = x * torch.rsqrt(variance + eps)
+        return x_normed * weight
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# RoPE op (LLaMA-specific)
+# ---------------------------------------------------------------------------
+
+
+@register_op("RoPE (Rotary Position Embedding)", "model_attention")
+def _rope_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        batch, num_heads, seq_len, head_dim = 32, 12, 256, 100
+        q = b.create_test_tensor((batch, num_heads, seq_len, head_dim))
+
+        # Precompute frequencies
+        inv_freq = 1.0 / (
+            10000.0
+            ** (
+                torch.arange(0, head_dim, 2, device=b.device, dtype=torch.float32)
+                / head_dim
+            )
+        )
+        t = torch.arange(seq_len, device=b.device, dtype=torch.float32)
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1).to(dtype=b.current_dtype)
+        cos_cached = emb.cos().unsqueeze(0).unsqueeze(0)
+        sin_cached = emb.sin().unsqueeze(0).unsqueeze(0)
+
+        # Apply rotation
+        q1 = q[..., : head_dim // 2]
+        q2 = q[..., head_dim // 2 :]
+        rotated = torch.cat((-q2, q1), dim=-1)
+        return q * cos_cached + rotated * sin_cached
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Causal attention op
+# ---------------------------------------------------------------------------
+
+
+@register_op("Causal SDPA (GPT-2/LLaMA)", "model_attention")
+def _causal_sdpa_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        seq_len = 256
+        q = b.create_test_tensor((32, 20, seq_len, 64))
+        k = b.create_test_tensor((32, 20, seq_len, 64))
+        v = b.create_test_tensor((32, 20, seq_len, 64))
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+    return op
+
+
+@register_op("Attention QK^T (LLaMA shape)", "model_attention")
+def _attn_qkt_llama_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        q = b.create_test_tensor((32, 12, 256, 100))
+        k = b.create_test_tensor((32, 12, 256, 100))
+        scale = 1.0 / (100.0**0.5)
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+        return torch.softmax(scores, dim=-1)
+
+    return op
+
+
+@register_op("Attention QK^T (GPT-2 shape)", "model_attention")
+def _attn_qkt_gpt2_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        q = b.create_test_tensor((32, 20, 256, 64))
+        k = b.create_test_tensor((32, 20, 256, 64))
+        scale = 1.0 / (64.0**0.5)
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+        # Causal mask
+        mask = torch.triu(
+            torch.ones(256, 256, device=b.device, dtype=torch.bool), diagonal=1
+        )
+        fill_val = -1e4 if b.current_dtype == torch.float16 else -1e9
+        scores = scores.masked_fill(mask.unsqueeze(0).unsqueeze(0), fill_val)
+        return torch.softmax(scores, dim=-1)
+
+    return op
+
+
+@register_op("Attention QK^T (BERT shape)", "model_attention")
+def _attn_qkt_bert_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        q = b.create_test_tensor((32, 16, 256, 64))
+        k = b.create_test_tensor((32, 16, 256, 64))
+        scale = 1.0 / (64.0**0.5)
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+        return torch.softmax(scores, dim=-1)
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# LSTM-specific ops
+# ---------------------------------------------------------------------------
+
+
+@register_op("LSTM Gate Computation", "model_recurrent")
+def _lstm_gate_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = b.create_test_tensor((32, 1024))
+        h = b.create_test_tensor((32, 1024))
+        w_ih = torch.randn(4096, 1024, device=b.device, dtype=b.current_dtype)
+        w_hh = torch.randn(4096, 1024, device=b.device, dtype=b.current_dtype)
+        b_ih = torch.randn(4096, device=b.device, dtype=b.current_dtype)
+        b_hh = torch.randn(4096, device=b.device, dtype=b.current_dtype)
+
+        gates = torch.mm(x, w_ih.t()) + b_ih + torch.mm(h, w_hh.t()) + b_hh
+        i, f, g, o = gates.chunk(4, dim=1)
+        i = torch.sigmoid(i)
+        f = torch.sigmoid(f)
+        g = torch.tanh(g)
+        o = torch.sigmoid(o)
+        return torch.cat([i, f, g, o], dim=1)
+
+    return op
+
+
+@register_op("LSTM Cell State Update", "model_recurrent")
+def _lstm_cell_update_op(b, size):
+    def op():
+        torch.manual_seed(42)
+        # Simulate 64 sequential cell state updates
+        c = torch.zeros(32, 1024, device=b.device, dtype=b.current_dtype)
+        for _ in range(64):
+            f_gate = torch.sigmoid(b.create_test_tensor((32, 1024)))
+            i_gate = torch.sigmoid(b.create_test_tensor((32, 1024)))
+            g_gate = torch.tanh(b.create_test_tensor((32, 1024)))
+            c = f_gate * c + i_gate * g_gate
+        h = torch.sigmoid(b.create_test_tensor((32, 1024))) * torch.tanh(c)
+        return h
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Composite pipeline tests
+# ---------------------------------------------------------------------------
+
+
+@register_pipeline("Transformer MLP")
+def _transformer_mlp_pipeline(b, size):
+    def pipeline():
+        x = b.create_test_tensor(size)
+        w1 = b.create_test_tensor(size)
+        w2 = b.create_test_tensor(size)
+        x = torch.matmul(x, w1)
+        x = torch.nn.functional.gelu(x)
+        x = torch.matmul(x, w2)
+        return x
+
+    return pipeline
+
+
+@register_pipeline("Attention Block")
+def _attention_block_pipeline(b, size):
+    def pipeline():
+        batch_size = 2
+        seq_len = min(size[0], 256)
+        hidden = min(size[1], 256)
+        num_heads = 4
+        head_dim = hidden // num_heads
+
+        x = b.create_test_tensor((batch_size, seq_len, hidden))
+
+        torch.manual_seed(42)
+        wq = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        wk = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        wv = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        wo = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+
+        q = (
+            torch.matmul(x, wq)
+            .view(batch_size, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+        k = (
+            torch.matmul(x, wk)
+            .view(batch_size, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+        v = (
+            torch.matmul(x, wv)
+            .view(batch_size, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+
+        attn = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        attn = attn.transpose(1, 2).contiguous().view(batch_size, seq_len, hidden)
+        out = torch.matmul(attn, wo)
+        return out
+
+    return pipeline
+
+
+@register_pipeline("Conv Block")
+def _conv_block_pipeline(b, size):
+    def pipeline():
+        x = b.create_test_tensor((16, 64, 32, 32))
+        conv = torch.nn.Conv2d(64, 128, 3, padding=1).to(
+            dtype=b.current_dtype, device=b.device
+        )
+        bn = torch.nn.BatchNorm2d(128).to(dtype=b.current_dtype, device=b.device)
+        bn.eval()
+        torch.manual_seed(42)
+        conv.weight.data = torch.randn_like(conv.weight.data)
+        conv.bias.data = torch.randn_like(conv.bias.data)
+        bn.weight.data = torch.randn_like(bn.weight.data)
+        bn.bias.data = torch.randn_like(bn.bias.data)
+        x = conv(x)
+        x = bn(x)
+        x = torch.relu(x)
+        return x
+
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# Model-accurate composite pipeline tests
+# ---------------------------------------------------------------------------
+# These pipelines replicate the exact operator chains from cpbench models.
+# Model-level SDC was detected but operator-level was not -- these
+# pipelines test the chained patterns that may expose hardware faults
+# only visible when operators interact.
+
+
+@register_pipeline("BERT Transformer Layer")
+def _bert_transformer_layer_pipeline(b, size):
+    def pipeline():
+        torch.manual_seed(42)
+        batch, seq_len, hidden = 32, 256, 1024
+        num_heads, head_dim = 16, 64
+
+        x = b.create_test_tensor((batch, seq_len, hidden))
+
+        # Self-attention with BERT shapes
+        wq = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        wk = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        wv = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        wo = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+
+        q = (
+            torch.matmul(x, wq)
+            .view(batch, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+        k = (
+            torch.matmul(x, wk)
+            .view(batch, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+        v = (
+            torch.matmul(x, wv)
+            .view(batch, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+
+        attn = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        attn = attn.transpose(1, 2).contiguous().view(batch, seq_len, hidden)
+        attn_out = torch.matmul(attn, wo)
+
+        # Post-attention LayerNorm + residual
+        ln1 = torch.nn.LayerNorm(hidden).to(dtype=b.current_dtype, device=b.device)
+        ln1.weight.data = torch.randn_like(ln1.weight.data)
+        ln1.bias.data = torch.randn_like(ln1.bias.data)
+        x = ln1(x + attn_out)
+
+        # FFN: Linear(1024->4096) + GELU + Linear(4096->1024)
+        w1 = torch.randn(hidden, 4096, device=b.device, dtype=b.current_dtype)
+        b1 = torch.randn(4096, device=b.device, dtype=b.current_dtype)
+        w2 = torch.randn(4096, hidden, device=b.device, dtype=b.current_dtype)
+        b2 = torch.randn(hidden, device=b.device, dtype=b.current_dtype)
+        ffn = torch.matmul(x, w1) + b1
+        ffn = torch.nn.functional.gelu(ffn)
+        ffn = torch.matmul(ffn, w2) + b2
+
+        # Post-FFN LayerNorm + residual
+        ln2 = torch.nn.LayerNorm(hidden).to(dtype=b.current_dtype, device=b.device)
+        ln2.weight.data = torch.randn_like(ln2.weight.data)
+        ln2.bias.data = torch.randn_like(ln2.bias.data)
+        return ln2(x + ffn)
+
+    return pipeline
+
+
+@register_pipeline("GPT-2 Transformer Layer")
+def _gpt2_transformer_layer_pipeline(b, size):
+    def pipeline():
+        torch.manual_seed(42)
+        batch, seq_len, hidden = 32, 256, 1280
+        num_heads, head_dim = 20, 64
+
+        x = b.create_test_tensor((batch, seq_len, hidden))
+
+        # Pre-norm (GPT-2 uses pre-LayerNorm)
+        ln1 = torch.nn.LayerNorm(hidden).to(dtype=b.current_dtype, device=b.device)
+        ln1.weight.data = torch.randn_like(ln1.weight.data)
+        ln1.bias.data = torch.randn_like(ln1.bias.data)
+        normed = ln1(x)
+
+        # Fused QKV projection (1280 -> 3840)
+        w_qkv = torch.randn(hidden, 3 * hidden, device=b.device, dtype=b.current_dtype)
+        b_qkv = torch.randn(3 * hidden, device=b.device, dtype=b.current_dtype)
+        qkv = torch.matmul(normed, w_qkv) + b_qkv
+        q, k, v = qkv.chunk(3, dim=-1)
+
+        q = q.view(batch, seq_len, num_heads, head_dim).transpose(1, 2)
+        k = k.view(batch, seq_len, num_heads, head_dim).transpose(1, 2)
+        v = v.view(batch, seq_len, num_heads, head_dim).transpose(1, 2)
+
+        # Causal attention
+        attn = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn = attn.transpose(1, 2).contiguous().view(batch, seq_len, hidden)
+
+        # Output projection
+        wo = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        attn_out = torch.matmul(attn, wo)
+
+        # Residual
+        x = x + attn_out
+
+        # Pre-norm for FFN
+        ln2 = torch.nn.LayerNorm(hidden).to(dtype=b.current_dtype, device=b.device)
+        ln2.weight.data = torch.randn_like(ln2.weight.data)
+        ln2.bias.data = torch.randn_like(ln2.bias.data)
+        normed2 = ln2(x)
+
+        # FFN: Linear(1280->5120) + GELU_new + Linear(5120->1280)
+        w1 = torch.randn(hidden, 4 * hidden, device=b.device, dtype=b.current_dtype)
+        b1 = torch.randn(4 * hidden, device=b.device, dtype=b.current_dtype)
+        w2 = torch.randn(4 * hidden, hidden, device=b.device, dtype=b.current_dtype)
+        b2 = torch.randn(hidden, device=b.device, dtype=b.current_dtype)
+        ffn = torch.matmul(normed2, w1) + b1
+        ffn = torch.nn.functional.gelu(ffn, approximate="tanh")
+        ffn = torch.matmul(ffn, w2) + b2
+
+        return x + ffn
+
+    return pipeline
+
+
+@register_pipeline("LLaMA Transformer Layer")
+def _llama_transformer_layer_pipeline(b, size):
+    def pipeline():
+        torch.manual_seed(42)
+        batch, seq_len, hidden = 32, 256, 1200
+        num_heads, head_dim = 12, 100
+        intermediate = 11008
+        eps = 1e-6
+
+        x = b.create_test_tensor((batch, seq_len, hidden))
+
+        # RMSNorm (pre-attention)
+        w_rms1 = torch.randn(hidden, device=b.device, dtype=b.current_dtype)
+        variance = x.pow(2).mean(-1, keepdim=True)
+        normed = x * torch.rsqrt(variance + eps) * w_rms1
+
+        # Q/K/V projections (no bias)
+        wq = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        wk = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        wv = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+
+        q = (
+            torch.matmul(normed, wq)
+            .view(batch, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+        k = (
+            torch.matmul(normed, wk)
+            .view(batch, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+        v = (
+            torch.matmul(normed, wv)
+            .view(batch, seq_len, num_heads, head_dim)
+            .transpose(1, 2)
+        )
+
+        # RoPE
+        inv_freq = 1.0 / (
+            10000.0
+            ** (
+                torch.arange(0, head_dim, 2, device=b.device, dtype=torch.float32)
+                / head_dim
+            )
+        )
+        t = torch.arange(seq_len, device=b.device, dtype=torch.float32)
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1).to(dtype=b.current_dtype)
+        cos_e = emb.cos().unsqueeze(0).unsqueeze(0)
+        sin_e = emb.sin().unsqueeze(0).unsqueeze(0)
+
+        q1, q2 = q[..., : head_dim // 2], q[..., head_dim // 2 :]
+        q = q * cos_e + torch.cat((-q2, q1), dim=-1) * sin_e
+        k1, k2 = k[..., : head_dim // 2], k[..., head_dim // 2 :]
+        k = k * cos_e + torch.cat((-k2, k1), dim=-1) * sin_e
+
+        # Causal attention
+        attn = torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn = attn.transpose(1, 2).contiguous().view(batch, seq_len, hidden)
+
+        # O projection
+        wo = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+        attn_out = torch.matmul(attn, wo)
+
+        # Residual
+        x = x + attn_out
+
+        # RMSNorm (pre-MLP)
+        w_rms2 = torch.randn(hidden, device=b.device, dtype=b.current_dtype)
+        variance2 = x.pow(2).mean(-1, keepdim=True)
+        normed2 = x * torch.rsqrt(variance2 + eps) * w_rms2
+
+        # SwiGLU MLP
+        w_gate = torch.randn(
+            hidden, intermediate, device=b.device, dtype=b.current_dtype
+        )
+        w_up = torch.randn(hidden, intermediate, device=b.device, dtype=b.current_dtype)
+        w_down = torch.randn(
+            intermediate, hidden, device=b.device, dtype=b.current_dtype
+        )
+
+        gate = torch.nn.functional.silu(torch.matmul(normed2, w_gate))
+        up = torch.matmul(normed2, w_up)
+        mlp_out = torch.matmul(gate * up, w_down)
+
+        return x + mlp_out
+
+    return pipeline
+
+
+@register_pipeline("LLaMA SwiGLU MLP")
+def _llama_swiglu_pipeline(b, size):
+    def pipeline():
+        torch.manual_seed(42)
+        hidden, intermediate = 1200, 11008
+        x = b.create_test_tensor((8192, hidden))
+
+        w_gate = torch.randn(
+            hidden, intermediate, device=b.device, dtype=b.current_dtype
+        )
+        w_up = torch.randn(hidden, intermediate, device=b.device, dtype=b.current_dtype)
+        w_down = torch.randn(
+            intermediate, hidden, device=b.device, dtype=b.current_dtype
+        )
+
+        gate = torch.nn.functional.silu(torch.matmul(x, w_gate))
+        up = torch.matmul(x, w_up)
+        return torch.matmul(gate * up, w_down)
+
+    return pipeline
+
+
+@register_pipeline("GPT-2 FFN Block")
+def _gpt2_ffn_pipeline(b, size):
+    def pipeline():
+        torch.manual_seed(42)
+        hidden = 1280
+        x = b.create_test_tensor((8192, hidden))
+
+        w1 = torch.randn(hidden, 4 * hidden, device=b.device, dtype=b.current_dtype)
+        b1 = torch.randn(4 * hidden, device=b.device, dtype=b.current_dtype)
+        w2 = torch.randn(4 * hidden, hidden, device=b.device, dtype=b.current_dtype)
+        b2 = torch.randn(hidden, device=b.device, dtype=b.current_dtype)
+
+        out = torch.matmul(x, w1) + b1
+        out = torch.nn.functional.gelu(out, approximate="tanh")
+        out = torch.matmul(out, w2) + b2
+        return out
+
+    return pipeline
+
+
+@register_pipeline("BERT FFN Block")
+def _bert_ffn_pipeline(b, size):
+    def pipeline():
+        torch.manual_seed(42)
+        hidden, intermediate = 1024, 4096
+        x = b.create_test_tensor((8192, hidden))
+
+        w1 = torch.randn(hidden, intermediate, device=b.device, dtype=b.current_dtype)
+        b1 = torch.randn(intermediate, device=b.device, dtype=b.current_dtype)
+        w2 = torch.randn(intermediate, hidden, device=b.device, dtype=b.current_dtype)
+        b2 = torch.randn(hidden, device=b.device, dtype=b.current_dtype)
+
+        out = torch.matmul(x, w1) + b1
+        out = torch.nn.functional.gelu(out)
+        out = torch.matmul(out, w2) + b2
+        return out
+
+    return pipeline
+
+
+@register_pipeline("LSTM Multi-Step Gates")
+def _lstm_multistep_pipeline(b, size):
+    def pipeline():
+        torch.manual_seed(42)
+        batch_sz, hidden = 32, 1024
+        w_ih = torch.randn(4096, 1024, device=b.device, dtype=b.current_dtype)
+        w_hh = torch.randn(4096, 1024, device=b.device, dtype=b.current_dtype)
+        b_ih = torch.randn(4096, device=b.device, dtype=b.current_dtype)
+        b_hh = torch.randn(4096, device=b.device, dtype=b.current_dtype)
+
+        h = torch.zeros(batch_sz, hidden, device=b.device, dtype=b.current_dtype)
+        c = torch.zeros(batch_sz, hidden, device=b.device, dtype=b.current_dtype)
+
+        # Run 32 timesteps to test sequential accumulation
+        for step in range(32):  # noqa: B007
+            x = b.create_test_tensor((batch_sz, hidden))
+            gates = torch.mm(x, w_ih.t()) + b_ih + torch.mm(h, w_hh.t()) + b_hh
+            i, f, g, o = gates.chunk(4, dim=1)
+            i = torch.sigmoid(i)
+            f = torch.sigmoid(f)
+            g = torch.tanh(g)
+            o = torch.sigmoid(o)
+            c = f * c + i * g
+            h = o * torch.tanh(c)
+
+        return h
+
+    return pipeline
+
+
+@register_pipeline("Multi-Layer Residual Chain")
+def _multi_layer_residual_pipeline(b, size):
+    def pipeline():
+        torch.manual_seed(42)
+        hidden = 1024
+        x = b.create_test_tensor((8192, hidden))
+
+        # Simulate 12 residual layers (like BERT)
+        for layer_idx in range(12):  # noqa: B007
+            w = torch.randn(hidden, hidden, device=b.device, dtype=b.current_dtype)
+            bias = torch.randn(hidden, device=b.device, dtype=b.current_dtype)
+            residual = x
+            x = torch.matmul(x, w) + bias
+            x = torch.nn.functional.gelu(x)
+            x = x + residual  # residual connection
+
+        return x
+
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# Backward pass operations — gradient computation exercises different CUDA
+# kernels than forward pass and is where training SDC often manifests.
+# ---------------------------------------------------------------------------
+
+
+@register_op("Backward Linear (BERT FFN)", "backward_pass")
+def _backward_linear_bert(b, size):
+    def op():
+        torch.manual_seed(42)
+        batch = 8192
+        x = torch.randn(
+            batch, 1024, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        w = torch.randn(
+            4096, 1024, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        y = torch.nn.functional.linear(x, w)
+        grad_out = torch.randn_like(y)
+        y.backward(grad_out)
+        # Return concatenation of both gradients for bit-exact comparison
+        return torch.cat([x.grad.flatten(), w.grad.flatten()]).cpu()
+
+    return op
+
+
+@register_op("Backward Linear (LLaMA SwiGLU Up)", "backward_pass")
+def _backward_linear_llama_up(b, size):
+    def op():
+        torch.manual_seed(42)
+        batch = 8192
+        x = torch.randn(
+            batch, 1200, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        w = torch.randn(
+            11008, 1200, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        y = torch.nn.functional.linear(x, w)
+        grad_out = torch.randn_like(y)
+        y.backward(grad_out)
+        return torch.cat([x.grad.flatten(), w.grad.flatten()]).cpu()
+
+    return op
+
+
+@register_op("Backward GELU", "backward_pass")
+def _backward_gelu(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = torch.randn(
+            8192, 4096, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        y = torch.nn.functional.gelu(x)
+        grad_out = torch.randn_like(y)
+        y.backward(grad_out)
+        return x.grad.cpu()
+
+    return op
+
+
+@register_op("Backward GELU New (tanh approx)", "backward_pass")
+def _backward_gelu_new(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = torch.randn(
+            8192, 5120, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        y = torch.nn.functional.gelu(x, approximate="tanh")
+        grad_out = torch.randn_like(y)
+        y.backward(grad_out)
+        return x.grad.cpu()
+
+    return op
+
+
+@register_op("Backward SiLU", "backward_pass")
+def _backward_silu(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = torch.randn(
+            8192, 11008, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        y = torch.nn.functional.silu(x)
+        grad_out = torch.randn_like(y)
+        y.backward(grad_out)
+        return x.grad.cpu()
+
+    return op
+
+
+@register_op("Backward LayerNorm", "backward_pass")
+def _backward_layernorm(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = torch.randn(
+            32, 256, 1024, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        ln = torch.nn.LayerNorm(1024, device=b.device, dtype=b.current_dtype)
+        y = ln(x)
+        grad_out = torch.randn_like(y)
+        y.backward(grad_out)
+        return x.grad.cpu()
+
+    return op
+
+
+@register_op("Backward RMSNorm", "backward_pass")
+def _backward_rmsnorm(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = torch.randn(
+            32, 256, 1200, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        weight = torch.randn(
+            1200, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        eps = 1e-5
+        variance = x.pow(2).mean(-1, keepdim=True)
+        y = x * torch.rsqrt(variance + eps) * weight
+        grad_out = torch.randn_like(y)
+        y.backward(grad_out)
+        return torch.cat([x.grad.flatten(), weight.grad.flatten()]).cpu()
+
+    return op
+
+
+@register_op("Backward Softmax", "backward_pass")
+def _backward_softmax(b, size):
+    def op():
+        torch.manual_seed(42)
+        x = torch.randn(
+            32, 16, 256, 256, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        y = torch.nn.functional.softmax(x, dim=-1)
+        grad_out = torch.randn_like(y)
+        y.backward(grad_out)
+        return x.grad.cpu()
+
+    return op
+
+
+@register_op("Backward Matmul (QK^T)", "backward_pass")
+def _backward_matmul_qkt(b, size):
+    def op():
+        torch.manual_seed(42)
+        # Simulates attention score backward: Q @ K^T
+        q = torch.randn(
+            32, 12, 256, 100, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        k = torch.randn(
+            32, 12, 256, 100, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        scores = torch.matmul(q, k.transpose(-2, -1)) / (100**0.5)
+        grad_out = torch.randn_like(scores)
+        scores.backward(grad_out)
+        return torch.cat([q.grad.flatten(), k.grad.flatten()]).cpu()
+
+    return op
+
+
+@register_op("Backward Attention Values (scores @ V)", "backward_pass")
+def _backward_attn_values(b, size):
+    def op():
+        torch.manual_seed(42)
+        # Simulates attention output backward: softmax(scores) @ V
+        attn_weights = torch.randn(
+            32, 12, 256, 256, device=b.device, dtype=b.current_dtype
+        )
+        attn_weights = torch.softmax(attn_weights, dim=-1).detach().requires_grad_(True)
+        v = torch.randn(
+            32, 12, 256, 100, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        out = torch.matmul(attn_weights, v)
+        grad_out = torch.randn_like(out)
+        out.backward(grad_out)
+        return torch.cat([attn_weights.grad.flatten(), v.grad.flatten()]).cpu()
+
+    return op
+
+
+@register_op("Backward Cross Entropy Loss", "backward_pass")
+def _backward_cross_entropy(b, size):
+    def op():
+        torch.manual_seed(42)
+        # Simulates LM head backward (logits -> loss)
+        logits = torch.randn(
+            8192, 32000, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        targets = torch.randint(0, 32000, (8192,), device=b.device)
+        loss = torch.nn.functional.cross_entropy(logits, targets)
+        loss.backward()
+        return logits.grad.cpu()
+
+    return op
+
+
+# ---------------------------------------------------------------------------
+# Training-mode pipelines — forward + backward + optimizer step.
+# These match what model-level SDC tests actually do.
+# ---------------------------------------------------------------------------
+
+
+@register_pipeline("Training Step: BERT FFN Layer")
+def _training_bert_ffn(b, size):
+    def pipeline():
+        num_steps = int(os.environ.get("CROSSGPU_TRAINING_STEPS", "4"))
+        torch.manual_seed(42)
+        batch, hidden, ffn_dim = 256, 1024, 4096
+
+        # Create "parameters"
+        w1 = torch.randn(
+            ffn_dim, hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        b1 = torch.randn(
+            ffn_dim, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        w2 = torch.randn(
+            hidden, ffn_dim, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        b2 = torch.randn(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        ln_w = torch.ones(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        ln_b = torch.zeros(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+
+        params = [w1, b1, w2, b2, ln_w, ln_b]
+        optimizer = torch.optim.Adam(params, lr=1e-4)
+
+        # Run training steps
+        all_grads = []
+        for step in range(num_steps):
+            torch.manual_seed(42 + step)
+            x = torch.randn(batch, hidden, device=b.device, dtype=b.current_dtype)
+            target = torch.randn(batch, hidden, device=b.device, dtype=b.current_dtype)
+
+            optimizer.zero_grad()
+            # LayerNorm
+            mean = x.mean(-1, keepdim=True)
+            var = x.var(-1, keepdim=True, unbiased=False)
+            x_norm = (x - mean) / torch.sqrt(var + 1e-5)
+            x_ln = x_norm * ln_w + ln_b
+            # FFN: up -> gelu -> down
+            h = torch.nn.functional.linear(x_ln, w1, b1)
+            h = torch.nn.functional.gelu(h)
+            out = torch.nn.functional.linear(h, w2, b2)
+            # Residual + loss
+            out = out + x
+            loss = torch.nn.functional.mse_loss(out, target)
+            loss.backward()
+            if num_steps <= 10:
+                all_grads.append(torch.cat([p.grad.flatten() for p in params]))
+            optimizer.step()
+
+        if num_steps > 10:
+            return torch.cat([p.flatten() for p in params]).cpu()
+        return torch.cat(all_grads).cpu()
+
+    return pipeline
+
+
+@register_pipeline("Training Step: LLaMA SwiGLU MLP")
+def _training_llama_mlp(b, size):
+    def pipeline():
+        num_steps = int(os.environ.get("CROSSGPU_TRAINING_STEPS", "4"))
+        torch.manual_seed(42)
+        batch, hidden, intermediate = 256, 1200, 11008
+
+        gate_proj = torch.randn(
+            intermediate,
+            hidden,
+            device=b.device,
+            dtype=b.current_dtype,
+            requires_grad=True,
+        )
+        up_proj = torch.randn(
+            intermediate,
+            hidden,
+            device=b.device,
+            dtype=b.current_dtype,
+            requires_grad=True,
+        )
+        down_proj = torch.randn(
+            hidden,
+            intermediate,
+            device=b.device,
+            dtype=b.current_dtype,
+            requires_grad=True,
+        )
+        rms_w = torch.ones(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+
+        params = [gate_proj, up_proj, down_proj, rms_w]
+        optimizer = torch.optim.Adam(params, lr=1e-4)
+
+        all_grads = []
+        for step in range(num_steps):
+            torch.manual_seed(42 + step)
+            x = torch.randn(batch, hidden, device=b.device, dtype=b.current_dtype)
+            target = torch.randn(batch, hidden, device=b.device, dtype=b.current_dtype)
+
+            optimizer.zero_grad()
+            # RMSNorm
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x_norm = x * torch.rsqrt(variance + 1e-5) * rms_w
+            # SwiGLU
+            gate = torch.nn.functional.silu(
+                torch.nn.functional.linear(x_norm, gate_proj)
+            )
+            up = torch.nn.functional.linear(x_norm, up_proj)
+            out = torch.nn.functional.linear(gate * up, down_proj)
+            # Residual + loss
+            out = out + x
+            loss = torch.nn.functional.mse_loss(out, target)
+            loss.backward()
+            if num_steps <= 10:
+                all_grads.append(torch.cat([p.grad.flatten() for p in params]))
+            optimizer.step()
+
+        if num_steps > 10:
+            # Stress mode: return final parameter state (accumulated corruption)
+            return torch.cat([p.flatten() for p in params]).cpu()
+        return torch.cat(all_grads).cpu()
+
+    return pipeline
+
+
+@register_pipeline("Training Step: Full Attention Block")
+def _training_attention(b, size):
+    def pipeline():
+        num_steps = int(os.environ.get("CROSSGPU_TRAINING_STEPS", "4"))
+        torch.manual_seed(42)
+        batch, seq, hidden, heads = 32, 128, 1024, 16
+        head_dim = hidden // heads
+
+        wq = torch.randn(
+            hidden, hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        wk = torch.randn(
+            hidden, hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        wv = torch.randn(
+            hidden, hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        wo = torch.randn(
+            hidden, hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        ln_w = torch.ones(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+
+        params = [wq, wk, wv, wo, ln_w]
+        optimizer = torch.optim.Adam(params, lr=1e-4)
+
+        all_grads = []
+        for step in range(num_steps):
+            torch.manual_seed(42 + step)
+            x = torch.randn(batch, seq, hidden, device=b.device, dtype=b.current_dtype)
+            target = torch.randn(
+                batch, seq, hidden, device=b.device, dtype=b.current_dtype
+            )
+
+            optimizer.zero_grad()
+            # RMSNorm
+            variance = x.pow(2).mean(-1, keepdim=True)
+            x_norm = x * torch.rsqrt(variance + 1e-5) * ln_w
+            # Q, K, V projections
+            q = (x_norm @ wq.t()).view(batch, seq, heads, head_dim).transpose(1, 2)
+            k = (x_norm @ wk.t()).view(batch, seq, heads, head_dim).transpose(1, 2)
+            v = (x_norm @ wv.t()).view(batch, seq, heads, head_dim).transpose(1, 2)
+            # Attention
+            scores = torch.matmul(q, k.transpose(-2, -1)) / (head_dim**0.5)
+            # Causal mask
+            mask = torch.triu(torch.ones(seq, seq, device=b.device), diagonal=1).bool()
+            scores = scores.masked_fill(mask, float("-inf"))
+            attn = torch.softmax(scores, dim=-1)
+            out = torch.matmul(attn, v)
+            out = out.transpose(1, 2).contiguous().view(batch, seq, hidden)
+            out = out @ wo.t()
+            # Residual + loss
+            out = out + x
+            loss = torch.nn.functional.mse_loss(out, target)
+            loss.backward()
+            if num_steps <= 10:
+                all_grads.append(torch.cat([p.grad.flatten() for p in params]))
+            optimizer.step()
+
+        if num_steps > 10:
+            return torch.cat([p.flatten() for p in params]).cpu()
+        return torch.cat(all_grads).cpu()
+
+    return pipeline
+
+
+@register_pipeline("Training Step: GPT-2 Transformer Layer")
+def _training_gpt2_layer(b, size):
+    def pipeline():
+        num_steps = int(os.environ.get("CROSSGPU_TRAINING_STEPS", "4"))
+        torch.manual_seed(42)
+        batch, seq, hidden = 16, 128, 1280
+        heads, head_dim = 20, 64
+        ffn_dim = 5120
+
+        # Attention params
+        w_qkv = torch.randn(
+            3 * hidden,
+            hidden,
+            device=b.device,
+            dtype=b.current_dtype,
+            requires_grad=True,
+        )
+        w_out = torch.randn(
+            hidden, hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        ln1_w = torch.ones(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        ln1_b = torch.zeros(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        # FFN params
+        w_fc = torch.randn(
+            ffn_dim, hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        b_fc = torch.randn(
+            ffn_dim, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        w_proj = torch.randn(
+            hidden, ffn_dim, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        b_proj = torch.randn(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        ln2_w = torch.ones(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+        ln2_b = torch.zeros(
+            hidden, device=b.device, dtype=b.current_dtype, requires_grad=True
+        )
+
+        params = [w_qkv, w_out, ln1_w, ln1_b, w_fc, b_fc, w_proj, b_proj, ln2_w, ln2_b]
+        optimizer = torch.optim.AdamW(params, lr=1e-4)
+
+        all_grads = []
+        for step in range(num_steps):
+            torch.manual_seed(42 + step)
+            x = torch.randn(batch, seq, hidden, device=b.device, dtype=b.current_dtype)
+            target = torch.randn(
+                batch, seq, hidden, device=b.device, dtype=b.current_dtype
+            )
+
+            optimizer.zero_grad()
+            residual = x
+            # Pre-LayerNorm
+            mean = x.mean(-1, keepdim=True)
+            var = x.var(-1, keepdim=True, unbiased=False)
+            x_n = (x - mean) / torch.sqrt(var + 1e-5) * ln1_w + ln1_b
+            # Fused QKV
+            qkv = torch.nn.functional.linear(x_n, w_qkv)
+            q, k, v = qkv.split(hidden, dim=-1)
+            q = q.view(batch, seq, heads, head_dim).transpose(1, 2)
+            k = k.view(batch, seq, heads, head_dim).transpose(1, 2)
+            v = v.view(batch, seq, heads, head_dim).transpose(1, 2)
+            # Causal attention
+            scores = torch.matmul(q, k.transpose(-2, -1)) / (head_dim**0.5)
+            mask = torch.triu(torch.ones(seq, seq, device=b.device), diagonal=1).bool()
+            scores = scores.masked_fill(mask, float("-inf"))
+            attn = torch.softmax(scores, dim=-1)
+            attn_out = torch.matmul(attn, v)
+            attn_out = attn_out.transpose(1, 2).contiguous().view(batch, seq, hidden)
+            attn_out = torch.nn.functional.linear(attn_out, w_out)
+            x = residual + attn_out
+            # FFN with pre-LayerNorm
+            residual2 = x
+            mean2 = x.mean(-1, keepdim=True)
+            var2 = x.var(-1, keepdim=True, unbiased=False)
+            x_n2 = (x - mean2) / torch.sqrt(var2 + 1e-5) * ln2_w + ln2_b
+            h = torch.nn.functional.linear(x_n2, w_fc, b_fc)
+            h = torch.nn.functional.gelu(h, approximate="tanh")
+            out = torch.nn.functional.linear(h, w_proj, b_proj)
+            out = residual2 + out
+            loss = torch.nn.functional.mse_loss(out, target)
+            loss.backward()
+            if num_steps <= 10:
+                all_grads.append(torch.cat([p.grad.flatten() for p in params]))
+            optimizer.step()
+
+        if num_steps > 10:
+            return torch.cat([p.flatten() for p in params]).cpu()
+        return torch.cat(all_grads).cpu()
+
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# Per-operator training pipelines — isolate individual GeMM operations.
+# When a pipeline fails, the name tells you exactly which operator is corrupt.
+# Use with --concurrent --num-workers 8 --training-steps 100 to trigger SDC.
+# ---------------------------------------------------------------------------
+
+
+def _single_linear_training_pipeline(name, in_features, out_features, batch=256):
+    """Factory for single Linear operator training pipelines."""
+
+    @register_pipeline(f"Training Step: {name} ({in_features}x{out_features})")
+    def _pipeline(b, size):
+        def pipeline():
+            num_steps = int(os.environ.get("CROSSGPU_TRAINING_STEPS", "4"))
+            torch.manual_seed(42)
+
+            weight = torch.randn(
+                out_features,
+                in_features,
+                device=b.device,
+                dtype=b.current_dtype,
+                requires_grad=True,
+            )
+            bias = torch.randn(
+                out_features,
+                device=b.device,
+                dtype=b.current_dtype,
+                requires_grad=True,
+            )
+
+            params = [weight, bias]
+            optimizer = torch.optim.Adam(params, lr=1e-5, foreach=True)
+
+            all_grads = []
+            for step in range(num_steps):
+                torch.manual_seed(42 + step)
+                x = torch.randn(
+                    batch, in_features, device=b.device, dtype=b.current_dtype
+                )
+                target = torch.randn(
+                    batch, out_features, device=b.device, dtype=b.current_dtype
+                )
+
+                optimizer.zero_grad()
+                out = torch.nn.functional.linear(x, weight, bias)
+                loss = torch.nn.functional.mse_loss(out, target)
+                loss.backward()
+                if num_steps <= 10:
+                    all_grads.append(torch.cat([p.grad.flatten() for p in params]))
+                optimizer.step()
+
+            if num_steps > 10:
+                return torch.cat([p.flatten() for p in params]).cpu()
+            return torch.cat(all_grads).cpu()
+
+        return pipeline
+
+    return _pipeline
+
+
+# LLaMA SwiGLU MLP individual projections (matches cpbench pytorch-llama-large)
+_single_linear_training_pipeline("gate_proj", 1200, 11008)
+_single_linear_training_pipeline("up_proj", 1200, 11008)
+_single_linear_training_pipeline("down_proj", 11008, 1200)
+
+# LLaMA attention projections
+_single_linear_training_pipeline("q_proj", 1200, 1200)
+_single_linear_training_pipeline("k_proj", 1200, 1200)
+_single_linear_training_pipeline("v_proj", 1200, 1200)
+_single_linear_training_pipeline("o_proj", 1200, 1200)
+
+# Classification head
+_single_linear_training_pipeline("linear_head", 1200, 100)

--- a/pytorch_op/precision.py
+++ b/pytorch_op/precision.py
@@ -1,0 +1,91 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Precision mode configuration and deterministic execution setup.
+
+Precision modes control which hardware datapath the GPU matmul unit uses.
+Each exercises different silicon -- a GPU can have SDC in one mode but not
+another (e.g., TF32/FP16/BF16 use reduced-precision datapaths while FP32
+uses the full-precision datapath within the same matrix core).
+"""
+
+import random
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Supported precision modes and their hardware paths:
+#   fp32  -- FP32 datapath in matrix core, full 32-bit mantissa
+#   tf32  -- TF32 datapath in matrix core, truncated 10-bit mantissa
+#   fp16  -- FP16 datapath in matrix core, half precision
+#   bf16  -- BF16 datapath in matrix core, bfloat16
+#   fp8   -- FP8 datapath in matrix core, 8-bit (E4M3/E5M2 variants)
+VALID_PRECISION_MODES = {"fp32", "tf32", "fp16", "bf16", "fp8"}
+
+# Map precision mode to torch dtype (for modes that change dtype).
+PRECISION_MODE_DTYPE = {
+    "fp32": torch.float32,
+    "tf32": torch.float32,  # TF32 is a backend mode, not a separate dtype
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    # fp8 handled specially -- torch.float8_e4m3fn
+}
+
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+
+
+def set_precision_mode(mode: str) -> None:
+    """Configure PyTorch backend for a specific precision mode.
+
+    This controls which hardware datapath the matmul unit uses.
+    Each mode exercises different silicon -- a GPU can have SDC
+    in one mode but not another.
+    """
+    if mode == "fp32":
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
+    elif mode == "tf32":
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+    elif mode in ("fp16", "bf16", "fp8"):
+        # Dtype-based -- tf32 backend setting is irrelevant
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
+    else:
+        raise ValueError(
+            f"Unknown precision mode: {mode}. Valid: {VALID_PRECISION_MODES}"
+        )
+
+
+def resolve_dtype(precision_mode: str) -> torch.dtype:
+    """Return the torch dtype for a given precision mode."""
+    if precision_mode == "fp8":
+        return torch.float8_e4m3fn
+    return PRECISION_MODE_DTYPE.get(precision_mode, torch.float32)
+
+
+def enable_deterministic_mode() -> None:
+    """Enable deterministic settings for reproducible results.
+
+    Sets seeds and forces deterministic algorithms. Does NOT configure
+    precision -- use set_precision_mode() for that.
+    """
+    seed = 42
+    torch.manual_seed(seed)
+    random.seed(seed)
+    try:
+        import numpy as np
+
+        np.random.seed(seed)
+    except ImportError:
+        pass
+    torch.cuda.manual_seed_all(seed)
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False

--- a/pytorch_op/randomize.py
+++ b/pytorch_op/randomize.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Parameter randomization for cross-GPU SDC detection.
+
+Randomizes test parameters across runs to maximize coverage when each
+individual run is time-limited. Over many runs, this ensures all
+hardware datapaths get exercised even if a single run can only test one.
+
+Currently supports:
+  --randomize-precision: randomly select one precision mode per run
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+
+from .precision import VALID_PRECISION_MODES
+
+logger: logging.Logger = logging.getLogger("pytorch_op")
+
+DEFAULT_PRECISION_POOL = ["fp32", "tf32", "fp16", "bf16"]
+
+
+def randomize_precision(
+    current_modes: list[str],
+    pool: list[str] | None = None,
+) -> list[str]:
+    """Pick one random precision mode for this run.
+
+    Args:
+        current_modes: the precision modes currently configured (from CLI).
+            Ignored when randomization is active — the random pick overrides.
+        pool: precision modes to choose from. Defaults to DEFAULT_PRECISION_POOL.
+
+    Returns:
+        A single-element list with the randomly chosen precision mode.
+    """
+    pool = pool or DEFAULT_PRECISION_POOL
+    pool = [m for m in pool if m in VALID_PRECISION_MODES]
+    if not pool:
+        logger.warning("No valid precision modes in pool, falling back to fp32")
+        return ["fp32"]
+
+    choice = random.choice(pool)
+    logger.info(f"Randomized precision mode: {choice} (from pool: {pool})")
+    return [choice]

--- a/run_benchmarks.py
+++ b/run_benchmarks.py
@@ -73,11 +73,14 @@ def _validate_dist_args(ctx, param, value):
     return value
 
 
-@click.command()
+@click.command(
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True}
+)
 @click.option(
     "--mode",
     type=click.Choice(["concurrent", "distributed", "sequential"]),
-    required=True,
+    default=None,
+    required=False,
     help="Mode to run the benchmarks: 'concurrent', 'distributed', 'sequential'.",
 )
 @click.option(
@@ -158,7 +161,16 @@ def _validate_dist_args(ctx, param, value):
     default="random",
     help='Comma-separated list of models to run (e.g., "alexnet,resnet,lstm,bert,gpt2,llama", or "random" which randomly select one model to run).',
 )
+@click.option(
+    "--test",
+    type=click.Choice(["model", "operator"]),
+    default="model",
+    help="Test type: 'model' runs training/inference benchmarks, "
+    "'operator' runs cross-GPU operator-level SDC detection.",
+)
+@click.pass_context
 def run_benchmarks(
+    ctx,
     mode,
     nnodes,
     rdzv_backend,
@@ -180,8 +192,19 @@ def run_benchmarks(
     monitoring_enabled,
     monitoring_interval,
     nproc_per_node,
+    test,
 ):
     """Run specified benchmarks on multiple GPU devices either concurrently, distributedly, or sequentially."""
+
+    if test == "operator":
+        import sys
+
+        from pytorch_op.main import main as op_main
+
+        sys.argv = [sys.argv[0]] + ctx.args
+        op_main()
+        return
+
     AcceleratorVendor.set(accelerator_vendor)
     monitor_executor = None
     stop_event = Event()


### PR DESCRIPTION
  Adds `pytorch_op/` module for operator-level GPU SDC (Silent Data Corruption) detection.

  Unlike model-level benchmarks that run full training workloads, this module isolates
  individual PyTorch operators and compares results across GPUs to catch
  deterministic-but-wrong errors at the operator level.
  
  ### Modes
  - **self** — Self-consistency: runs each op N times on a single GPU, checks bit-exact
  reproducibility
  - **cross-gpu** — Cross-GPU comparison: runs the same op on all GPUs with identical
  inputs, compares results (recommended)
  - **sweep** — Systematic HBM coverage: staircase memory fill to test different GPU memory
  regions

  ### Presets
  - `quick` — 1 iteration, all ops, 4kx4k (~1-2 min)
  - `standard` — 3 iterations, all ops + pipelines (~5 min)
  - `thorough` — 10 iterations + full HBM sweep (~25-30 min)

  ### Coverage
  - 85 individual ops: arithmetic, matrix, reduction, activation, convolution, memory,
  normalization, attention, embedding, pooling, scatter/gather, sorting, backward pass
  - 15 composite pipelines: BERT/GPT-2/LLaMA transformer layers, SwiGLU MLP, training steps
  with optimizer
  - Precision modes: fp32, tf32, fp16, bf16, fp8
  - Supports NVIDIA and AMD GPUs

  ## Usage
  
  ```bash
  python -m pytorch_op --preset quick               # Quick SDC check, all GPUs
  python -m pytorch_op --preset quick --fail-fast    # Stop on first failure
  python -m pytorch_op --preset quick -v             # Full detail on failures
  python -m pytorch_op --mode sweep                  # Systematic full-HBM scan
  python -m pytorch_op --mode self                   # Self-test all GPUs
  python -m pytorch_op --list-ops                    # List all registered ops

  Test plan

  Tested on 8x AMD MI300X (Instinct) host:

  $ python -m pytorch_op --preset quick --duration-limit 60
  ALL CROSS-GPU TESTS PASSED - 85 comparisons across 8 GPUs in 57.3s
  Result: {'total_comparisons': 85, 'passed': 85, 'failed': 0}
